### PR TITLE
FACT-359 - Upgraded from Spring Boot 2.3.6.RELEASE to 2.3.9.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.3.6.RELEASE'
+  id 'org.springframework.boot' version '2.3.9.RELEASE'
   id 'org.owasp.dependencycheck' version '6.1.1'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.1.1'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-359


### Change description ###
This stems from a recent CVE that is high enough risk to block building the API any further. I've identified a spring version (2.3.9.RELEASE) which is still compatible with the current codebase, which will bring the spring.framework.security dependency up to 5.3.8.RELEASE. This should mitigate the issue exploit whilst still ensuring compatibility across the board with our codebase.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
