### PR TITLE
FACT-365 - SearchController now return empty list if requesting court serving Children law in Scotland

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
@@ -13,12 +13,8 @@ import uk.gov.hmcts.dts.fact.model.ServiceAreaWithCourtReferencesWithDistance;
 import uk.gov.hmcts.dts.fact.model.deprecated.CourtWithDistance;
 import uk.gov.hmcts.dts.fact.services.CourtService;
 
-import javax.annotation.RegEx;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.springframework.http.ResponseEntity.badRequest;
 import static org.springframework.http.ResponseEntity.ok;
@@ -31,7 +27,6 @@ import static org.springframework.http.ResponseEntity.ok;
 public class SearchController {
 
     private final CourtService courtService;
-    private final Pattern scottishPostcodeRegex = Pattern.compile("^(ZE|KW|IV|HS|PH|AB|DD|PA|FK|G[0-9]|KY|KA|DG|TD|EH|ML)", Pattern.CASE_INSENSITIVE);
 
     @Autowired
     public SearchController(final CourtService courtService) {
@@ -53,10 +48,6 @@ public class SearchController {
         @RequestParam(required = false, name = "q") Optional<String> query
     ) {
         if (postcode.isPresent() && areaOfLaw.isPresent()) {
-            if(areaOfLaw.get().equals("Children") && scottishPostcodeRegex.matcher(postcode.get()).find()) {
-                return ok(Collections.emptyList());
-            }
-
             return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLaw(postcode.get(), areaOfLaw.get()));
         } else if (postcode.isPresent()) {
             return ok(courtService.getNearestCourtsByPostcode(postcode.get()));

--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
@@ -13,8 +13,12 @@ import uk.gov.hmcts.dts.fact.model.ServiceAreaWithCourtReferencesWithDistance;
 import uk.gov.hmcts.dts.fact.model.deprecated.CourtWithDistance;
 import uk.gov.hmcts.dts.fact.services.CourtService;
 
+import javax.annotation.RegEx;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.springframework.http.ResponseEntity.badRequest;
 import static org.springframework.http.ResponseEntity.ok;
@@ -27,6 +31,7 @@ import static org.springframework.http.ResponseEntity.ok;
 public class SearchController {
 
     private final CourtService courtService;
+    private final Pattern scottishPostcodeRegex = Pattern.compile("^(ZE|KW|IV|HS|PH|AB|DD|PA|FK|G[0-9]|KY|KA|DG|TD|EH|ML)", Pattern.CASE_INSENSITIVE);
 
     @Autowired
     public SearchController(final CourtService courtService) {
@@ -35,7 +40,7 @@ public class SearchController {
 
     /**
      * Find court by postcode.
-     * 
+     *
      * @deprecated Use {@link #findCourtsByPostcodeAndServiceArea}, path = /results}
      */
     @Deprecated(since = "1.0", forRemoval = true)
@@ -48,6 +53,10 @@ public class SearchController {
         @RequestParam(required = false, name = "q") Optional<String> query
     ) {
         if (postcode.isPresent() && areaOfLaw.isPresent()) {
+            if(areaOfLaw.get().equals("Children") && scottishPostcodeRegex.matcher(postcode.get()).find()) {
+                return ok(Collections.emptyList());
+            }
+
             return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLaw(postcode.get(), areaOfLaw.get()));
         } else if (postcode.isPresent()) {
             return ok(courtService.getNearestCourtsByPostcode(postcode.get()));

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.dts.fact.util.Utils.isChildrenAreaOfLaw;
+import static uk.gov.hmcts.dts.fact.util.Utils.isScottishPostcode;
 
 @Service
 public class CourtService {
@@ -85,13 +87,15 @@ public class CourtService {
     }
 
     public List<CourtWithDistance> getNearestCourtsByPostcodeAndAreaOfLaw(final String postcode, final String areaOfLaw) {
-        return mapitService.getMapitData(postcode)
-            .map(value -> courtWithDistanceRepository
-                .findNearestTenByAreaOfLaw(value.getLat(), value.getLon(), areaOfLaw)
-                .stream()
-                .map(CourtWithDistance::new)
-                .collect(toList()))
-            .orElse(emptyList());
+        return isScottishPostcode(postcode) && isChildrenAreaOfLaw(areaOfLaw)
+            ? emptyList()
+            : mapitService.getMapitData(postcode)
+                .map(value -> courtWithDistanceRepository
+                    .findNearestTenByAreaOfLaw(value.getLat(), value.getLon(), areaOfLaw)
+                    .stream()
+                    .map(CourtWithDistance::new)
+                    .collect(toList()))
+                .orElse(emptyList());
     }
 
     public ServiceAreaWithCourtReferencesWithDistance getNearestCourtsByPostcodeSearch(final String postcode, final String serviceAreaSlug) {

--- a/src/main/java/uk/gov/hmcts/dts/fact/util/Utils.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/util/Utils.java
@@ -5,14 +5,15 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 public final class Utils {
 
     public static final Predicate<uk.gov.hmcts.dts.fact.entity.Contact> NAME_IS_DX = c -> "DX".equalsIgnoreCase(c.getName());
     public static final Predicate<uk.gov.hmcts.dts.fact.entity.Contact> NAME_IS_NOT_DX = NAME_IS_DX.negate();
+    private static final Pattern SCOTTISH_POSTCODE_AREA_REGEX = Pattern.compile("^(ZE|KW|IV|HS|PH|AB|DD|PA|FK|G[0-9]|KY|KA|DG|TD|EH|ML)", Pattern.CASE_INSENSITIVE);
 
     private Utils() {
-
     }
 
     public static String stripHtmlFromString(String text) {
@@ -32,5 +33,13 @@ public final class Utils {
     public static String chooseString(String welsh, String english) {
         boolean welshPreferred = LocaleContextHolder.getLocale().getLanguage().equals("cy");
         return welshPreferred && null != welsh && !welsh.isBlank() ? welsh : english;
+    }
+
+    public static boolean isScottishPostcode(final String postcode) {
+        return SCOTTISH_POSTCODE_AREA_REGEX.matcher(postcode).find();
+    }
+
+    public static boolean isChildrenAreaOfLaw(final String areaOfLaw) {
+        return "Children".equalsIgnoreCase(areaOfLaw);
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
@@ -31,12 +31,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = CourtService.class)
@@ -46,6 +42,8 @@ class CourtServiceTest {
     private static final String SOME_SLUG = "some-slug";
     private static final String AREA_OF_LAW_NAME = "AreaOfLawName";
     private static final String JE2_4BA = "JE2 4BA";
+    private static final String ZE2_9TE = "ZE2 9TE";
+    private static final String CHILDREN = "children";
     private static final String TAX = "tax";
 
     @Autowired
@@ -93,7 +91,7 @@ class CourtServiceTest {
 
         when(courtRepository.queryBy(query)).thenReturn(singletonList(court));
         final List<CourtReference> results = courtService.getCourtByNameOrAddressOrPostcodeOrTown(query);
-        assertThat(results.size()).isEqualTo(1);
+        assertThat(results).hasSize(1);
         assertThat(results.get(0)).isInstanceOf(CourtReference.class);
     }
 
@@ -105,7 +103,7 @@ class CourtServiceTest {
         when(courtRepository.queryBy(query)).thenReturn(singletonList(court));
         final List<CourtWithDistance> results = courtService.getCourtsByNameOrAddressOrPostcodeOrTown(query);
         assertThat(results.get(0)).isInstanceOf(CourtWithDistance.class);
-        assertThat(results.size()).isEqualTo(1);
+        assertThat(results).hasSize(1);
     }
 
     @Test
@@ -121,7 +119,7 @@ class CourtServiceTest {
         when(courtWithDistanceRepository.findNearestTen(anyDouble(), anyDouble())).thenReturn(courts);
 
         final List<CourtWithDistance> results = courtService.getNearestCourtsByPostcode("OX1 1RZ");
-        assertThat(results.size()).isEqualTo(10);
+        assertThat(results).hasSize(10);
         assertThat(results.get(0)).isInstanceOf(CourtWithDistance.class);
     }
 
@@ -131,7 +129,7 @@ class CourtServiceTest {
         when(mapitService.getMapitData(any())).thenReturn(empty());
 
         final List<CourtWithDistance> results = courtService.getNearestCourtsByPostcode("JE3 4BA");
-        assertThat(results.isEmpty()).isTrue();
+        assertThat(results).isEmpty();
         verifyNoInteractions(courtRepository);
     }
 
@@ -159,7 +157,7 @@ class CourtServiceTest {
             "OX2 1RZ",
             AREA_OF_LAW_NAME
         );
-        assertThat(results.size()).isEqualTo(10);
+        assertThat(results).hasSize(10);
         assertThat(results.get(0)).isInstanceOf(CourtWithDistance.class);
     }
 
@@ -170,10 +168,22 @@ class CourtServiceTest {
 
         final List<CourtWithDistance> results = courtService.getNearestCourtsByPostcodeAndAreaOfLaw(
             JE2_4BA,
-            AREA_OF_LAW_NAME
+            CHILDREN
         );
 
-        assertThat(results.isEmpty()).isTrue();
+        assertThat(results).isEmpty();
+        verifyNoInteractions(courtRepository);
+    }
+
+    @Test
+    void shouldReturnEmptyListForScottishPostcodeAndChildrenAreaOfLaw() {
+        final List<CourtWithDistance> results = courtService.getNearestCourtsByPostcodeAndAreaOfLaw(
+            ZE2_9TE,
+            CHILDREN
+        );
+
+        assertThat(results).isEmpty();
+        verifyNoInteractions(mapitService);
         verifyNoInteractions(courtRepository);
     }
 
@@ -201,7 +211,7 @@ class CourtServiceTest {
         );
 
         assertThat(results.getSlug()).isEqualTo(serviceAreaSlug);
-        assertThat(results.getCourts().size()).isEqualTo(2);
+        assertThat(results.getCourts()).hasSize(2);
         assertThat(results.getCourts().get(0)).isInstanceOf(CourtReferenceWithDistance.class);
     }
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/util/UtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/util/UtilsTest.java
@@ -1,17 +1,21 @@
 package uk.gov.hmcts.dts.fact.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import uk.gov.hmcts.dts.fact.entity.Contact;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.hmcts.dts.fact.util.Utils.chooseString;
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.hmcts.dts.fact.util.Utils.*;
 
 class UtilsTest {
 
@@ -106,5 +110,29 @@ class UtilsTest {
         LocaleContextHolder.resetLocaleContext();
     }
 
+    private static Stream<Arguments> parameterForScottishPostcodes() {
+        return Stream.of(
+            Arguments.of("ZE2 9TE", true),
+            Arguments.of("EH1 1BJ", true),
+            Arguments.of("G1 1UT", true),
+            Arguments.of("GU1 1AF", false),
+            Arguments.of("M1 7EP", false)
+        );
+    }
 
+    @ParameterizedTest
+    @MethodSource("parameterForScottishPostcodes")
+    void testForScottishPostcodes(final String postcode, final boolean expectedResult) {
+        assertEquals(isScottishPostcode(postcode), expectedResult);
+    }
+
+    @Test
+    void shouldReturnTrueForChildrenAreaOfLaw() {
+        assertTrue(isChildrenAreaOfLaw("Children"));
+    }
+
+    @Test
+    void shouldReturnFalseForTaxAreaOfLaw() {
+        assertFalse(isChildrenAreaOfLaw("Tax"));
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-365

### Change description ###
Added if statement to determine if request is looking for courts in Scotland serving Children area of law.
Return empty list if they are (due to not being handled by HMCTS)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
