### PR TITLE
FACT-378 - Fixed issues with local authority not being taken into account on deprecated search endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
@@ -35,7 +35,6 @@ public class SearchController {
 
     /**
      * Find court by postcode.
-     * 
      * @deprecated Use {@link #findCourtsByPostcodeAndServiceArea}, path = /results}
      */
     @Deprecated(since = "1.0", forRemoval = true)
@@ -48,6 +47,11 @@ public class SearchController {
         @RequestParam(required = false, name = "q") Optional<String> query
     ) {
         if (postcode.isPresent() && areaOfLaw.isPresent()) {
+            switch(areaOfLaw.get().toLowerCase()) {
+                case "children":
+                    return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority(postcode.get(), areaOfLaw.get()));
+            }
+
             return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLaw(postcode.get(), areaOfLaw.get()));
         } else if (postcode.isPresent()) {
             return ok(courtService.getNearestCourtsByPostcode(postcode.get()));

--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
@@ -47,11 +47,9 @@ public class SearchController {
         @RequestParam(required = false, name = "q") Optional<String> query
     ) {
         if (postcode.isPresent() && areaOfLaw.isPresent()) {
-            switch(areaOfLaw.get().toLowerCase()) {
-                case "children":
-                    return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority(postcode.get(), areaOfLaw.get()));
+            if (areaOfLaw.get().equals("Children")) {
+                return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority(postcode.get(), areaOfLaw.get()));
             }
-
             return ok(courtService.getNearestCourtsByPostcodeAndAreaOfLaw(postcode.get(), areaOfLaw.get()));
         } else if (postcode.isPresent()) {
             return ok(courtService.getNearestCourtsByPostcode(postcode.get()));

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
@@ -94,6 +94,23 @@ public class CourtService {
             .orElse(emptyList());
     }
 
+    public List<CourtWithDistance> getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority(final String postcode, final String areaOfLaw) {
+        final Optional<MapitData> optionalMapitData = mapitService.getMapitData(postcode);
+        if (optionalMapitData.isEmpty()) {
+            return emptyList();
+        }
+
+        final MapitData mapitData = optionalMapitData.get();
+
+        return mapitData.getLocalAuthority()
+            .map(localAuthority -> courtWithDistanceRepository
+                .findNearestTenByAreaOfLawAndLocalAuthority(mapitData.getLat(), mapitData.getLon(), areaOfLaw, localAuthority)
+                .stream()
+                .map(CourtWithDistance::new)
+                .collect(toList()))
+            .orElse(emptyList());
+    }
+
     public ServiceAreaWithCourtReferencesWithDistance getNearestCourtsByPostcodeSearch(final String postcode, final String serviceAreaSlug) {
 
         final Optional<ServiceArea> serviceAreaOptional = serviceAreaRepository.findBySlugIgnoreCase(serviceAreaSlug);

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/SearchControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/SearchControllerTest.java
@@ -52,6 +52,14 @@ class SearchControllerTest {
     }
 
     @Test
+    void shouldSearchByPostcodeAndAreaOfLawAndLocalAuthority() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/results.json?postcode=BN21 2BH&aol=Children"))
+            .andExpect(status().isOk());
+
+        verify(courtService).getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority("BN21 2BH", "Children");
+    }
+
+    @Test
     void shouldSearchByNameOrAddress() throws Exception {
         mockMvc.perform(get(BASE_URL + "/results.json?q=name"))
             .andExpect(status().isOk());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-376
https://tools.hmcts.net/jira/browse/FACT-378


### Change description ###
Implemented ability to search by postcode area of law and local authority.
Only used when deprecated API is used for 'Children' area of law requests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
