### PR TITLE
FACT-375 - Add custom health check for mapit and incorporate that into existing healthcheck

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/dts/fact/ApplicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/dts/fact/ApplicationTest.java
@@ -12,7 +12,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
@@ -28,7 +30,7 @@ public class ApplicationTest {
 
     @BeforeEach
     void setUp() {
-        WebRequestTrackingFilter filter = new WebRequestTrackingFilter();
+        final WebRequestTrackingFilter filter = new WebRequestTrackingFilter();
         filter.init(new MockFilterConfig());
         mockMvc = webAppContextSetup(wac).addFilters(filter).build();
     }
@@ -39,9 +41,15 @@ public class ApplicationTest {
 
     @Test
     public void welcomeRootEndpoint() throws Exception {
-        MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
+        final MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
 
         assertThat(response.getResponse().getContentAsString()).startsWith("Welcome");
     }
 
+    @Test
+    public void healthEndpointWithCustomMapitServiceHealthCheck() throws Exception {
+        mockMvc.perform(get("/health"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"mapit\":{\"status\":\"UP\"")));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/CourtsController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/CourtsController.java
@@ -5,13 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.dts.fact.exception.NotFoundException;
 import uk.gov.hmcts.dts.fact.model.Court;
 import uk.gov.hmcts.dts.fact.model.CourtReference;
@@ -21,7 +15,6 @@ import uk.gov.hmcts.dts.fact.services.CourtService;
 import java.util.List;
 
 import static org.springframework.http.ResponseEntity.ok;
-
 
 @RestController
 @RequestMapping(

--- a/src/main/java/uk/gov/hmcts/dts/fact/mapit/MapItService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/mapit/MapItService.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.dts.fact.mapit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class MapItService {
+    @Value("${mapit.url}")
+    private String mapitUrl;
+
+    @Value("${mapit.endpoint.quota}")
+    private String mapitQuotaPath;
+
+    public boolean isUp() {
+        final ResponseEntity<JsonNode> responseEntity = new RestTemplate().getForEntity(getMapitQuotaEndpoint(), JsonNode.class);
+        return responseEntity.getStatusCode().equals(HttpStatus.OK);
+    }
+
+    private String getMapitQuotaEndpoint() {
+        return mapitUrl + mapitQuotaPath;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/dts/fact/mapit/MapitClient.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/mapit/MapitClient.java
@@ -4,10 +4,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "mappitApi", url = "https://mapit.mysociety.org/")
+@FeignClient(name = "mappitApi", url = "${mapit.url}")
 public interface MapitClient {
 
-    @GetMapping("/postcode/{postcode}")
+    @GetMapping("${mapit.endpoint.postcode-search}/{postcode}")
     MapitData getMapitData(@PathVariable("postcode") String postcode);
 }
 

--- a/src/main/java/uk/gov/hmcts/dts/fact/mapit/MapitHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/mapit/MapitHealthIndicator.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.dts.fact.mapit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MapitHealthIndicator implements HealthIndicator {
+    @Autowired
+    private MapItService mapItService;
+
+    @Override
+    public Health health() {
+        try {
+            return mapItService.isUp()
+                ? Health.up().build()
+                : Health.down().build();
+        } catch (final Exception e) {
+            return Health.down().withException(e).build();
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,7 +45,12 @@ spring:
 dbMigration:
   runOnStartup: ${RUN_DB_MIGRATION_ON_STARTUP:true}
 
-mapit.key: ${MAPIT_KEY:}
+mapit:
+  key: ${MAPIT_KEY:}
+  url: https://mapit.mysociety.org
+  endpoint:
+    postcode-search: /postcode
+    quota: /quota
 
 azure:
   application-insights:

--- a/src/test/java/uk/gov/hmcts/dts/fact/mapit/MapitHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/mapit/MapitHealthIndicatorTest.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.dts.fact.mapit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MapitHealthIndicatorTest {
+    @Mock
+    private MapItService mapItService;
+
+    @InjectMocks
+    private MapitHealthIndicator healthIndicator;
+
+    @Test
+    void shouldReturnHealthStatusUpWhenMapitServiceIsRunnning() {
+        when(mapItService.isUp()).thenReturn(true);
+        assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void shouldReturnHealthStatusDownWhenMapitServiceIsNotRunnning() {
+        when(mapItService.isUp()).thenReturn(false);
+        assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
+    }
+
+    @Test
+    void shouldReturnHealthStatusDownWhenExceptionIsThrownWhenAccessingMapitService() {
+        doThrow(RuntimeException.class).when(mapItService).isUp();
+        assertThat(healthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-375

### Change description ###

Add the ability to check whether the Mapit service is up and running when calling the FaCT API health endpoint. If the Mapit service is down, the overall health status will be down.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
