### PR TITLE
FACT-364 - Updated deprecated endpoint to make use of new exception for invalid postcodes

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/SearchController.java
@@ -3,12 +3,11 @@ package uk.gov.hmcts.dts.fact.controllers;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.hmcts.dts.fact.exception.InvalidPostcodeException;
 import uk.gov.hmcts.dts.fact.model.ServiceAreaWithCourtReferencesWithDistance;
 import uk.gov.hmcts.dts.fact.model.deprecated.CourtWithDistance;
 import uk.gov.hmcts.dts.fact.services.CourtService;
@@ -72,5 +71,11 @@ public class SearchController {
         } else {
             return badRequest().build();
         }
+    }
+
+    @ExceptionHandler(InvalidPostcodeException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    String postcodeNotFoundHandler(InvalidPostcodeException ex) {
+        return ex.getMessage();
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/InvalidPostcodeException.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/InvalidPostcodeException.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.dts.fact.exception;
+
+public class InvalidPostcodeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1580364997241986088L;
+
+    public InvalidPostcodeException(String postcode) {
+        super("Postcode '" + postcode + "' is not valid");
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
@@ -102,7 +102,7 @@ public class CourtService {
 
         final MapitData mapitData = optionalMapitData.get();
 
-        return mapitService.getMapitData(postcode).get().getLocalAuthority()
+        return mapitData.getLocalAuthority()
             .map(localAuthority -> courtWithDistanceRepository
                 .findNearestTenByAreaOfLawAndLocalAuthority(mapitData.getLat(), mapitData.getLon(), areaOfLaw, localAuthority)
                 .stream()

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.dts.fact.services.search.ServiceAreaSearchFactory;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 @Service

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.dts.fact.util.Utils.isNorthernIrishPostcode;
 import static uk.gov.hmcts.dts.fact.util.Utils.isScottishPostcode;

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/CourtService.java
@@ -92,7 +92,7 @@ public class CourtService {
                 .stream()
                 .map(CourtWithDistance::new)
                 .collect(toList()))
-            .orElse(emptyList());
+            .orElseThrow(() -> new InvalidPostcodeException(postcode));
     }
 
     public List<CourtWithDistance> getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority(final String postcode, final String areaOfLaw) {

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.dts.fact.entity.AreaOfLaw;
 import uk.gov.hmcts.dts.fact.entity.Court;
 import uk.gov.hmcts.dts.fact.entity.ServiceArea;
+import uk.gov.hmcts.dts.fact.exception.InvalidPostcodeException;
 import uk.gov.hmcts.dts.fact.exception.NotFoundException;
 import uk.gov.hmcts.dts.fact.mapit.MapitData;
 import uk.gov.hmcts.dts.fact.model.CourtReference;
@@ -160,8 +161,9 @@ class CourtServiceTest {
 
         when(mapitService.getMapitData(any())).thenReturn(empty());
 
-        final List<CourtWithDistance> results = courtService.getNearestCourtsByPostcode("JE3 4BA");
-        assertThat(results.isEmpty()).isTrue();
+        assertThrows(InvalidPostcodeException.class, () -> {
+            courtService.getNearestCourtsByPostcode("JE3 4BA");
+        });
         verifyNoInteractions(courtRepository);
     }
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
@@ -199,13 +199,13 @@ class CourtServiceTest {
     void shouldReturnEmptyListForFilterSearchByAreaOfLawIfNoCoordinates() {
 
         when(mapitService.getMapitData(any())).thenReturn(empty());
+        assertThrows(InvalidPostcodeException.class, () -> {
+            courtService.getNearestCourtsByPostcodeAndAreaOfLaw(
+                JE2_4BA,
+                AREA_OF_LAW_NAME
+            );
+        });
 
-        final List<CourtWithDistance> results = courtService.getNearestCourtsByPostcodeAndAreaOfLaw(
-            JE2_4BA,
-            AREA_OF_LAW_NAME
-        );
-
-        assertThat(results.isEmpty()).isTrue();
         verifyNoInteractions(courtRepository);
     }
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
@@ -157,7 +157,7 @@ class CourtServiceTest {
     }
 
     @Test
-    void shouldReturnEmptyListOfCourtsIfNoCoordinates() {
+    void shouldReturnExceptionIfNoCoordinates() {
 
         when(mapitService.getMapitData(any())).thenReturn(empty());
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
@@ -260,6 +260,9 @@ class CourtServiceTest {
     @ParameterizedTest
     @MethodSource("parametersForPostcodeSearchWithoutLocalAuthority")
     void shouldNotUseMapitServiceForScottishOrNorthernIrishPostcodeSearch(final String postcode, final String areaOfLaw, final boolean useMapitService) {
+        if (useMapitService) {
+            when(mapitService.getMapitData(anyString())).thenReturn(Optional.of(new MapitData()));
+        }
         courtService.getNearestCourtsByPostcodeAndAreaOfLaw(postcode, areaOfLaw);
         if (useMapitService) {
             verify(mapitService).getMapitData(postcode);
@@ -289,6 +292,11 @@ class CourtServiceTest {
     @ParameterizedTest
     @MethodSource("parametersForPostcodeSearchWithLocalAuthority")
     void shouldNotUseMapitServiceForScottishOrNorthernIrishPostcodeSearchWithLocalAuthority(final String postcode, final boolean useMapitService) {
+        if (useMapitService) {
+            MapitData mockData = mock(MapitData.class);
+            when(mockData.getLocalAuthority()).thenReturn(Optional.of(LOCAL_AUTHORITY_NAME));
+            when(mapitService.getMapitData(anyString())).thenReturn(Optional.of(mockData));
+        }
         courtService.getNearestCourtsByPostcodeAndAreaOfLawAndLocalAuthority(postcode, CHILDREN);
         if (useMapitService) {
             verify(mapitService).getMapitData(postcode);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-364

### Change description ###
Added new exception and subsequent handler to determine that MapIt has been supplied with an invalid postcode.
Updated test to expect InvalidPostcodeException rather than an empty array.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
