### PR TITLE
FACT-448 - Patch for CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,10 @@ dependencyManagement {
     dependencySet(group: 'com.google.guava', version: '30.1.1-jre') {
       entry 'guava'
     }
+    //CVE-2021-29425
+    dependencySet(group: 'commons-io', version: '2.8.0') {
+      entry 'commons-io'
+    }
   }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-448


### Change description ###

Patch for CVE-2021-29425, specified apache commons-io to a version which has this issue patched.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
