### PR TITLE
FACT-408 - Fix issue with adding new opening times to courts with no existing opening times

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtGeneralInfoEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtGeneralInfoEndpointTest.java
@@ -15,8 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpStatus.*;
-import static uk.gov.hmcts.dts.fact.util.TestUtil.BEARER;
-import static uk.gov.hmcts.dts.fact.util.TestUtil.COURTS_ENDPOINT;
+import static uk.gov.hmcts.dts.fact.util.TestUtil.*;
 
 @ExtendWith(SpringExtension.class)
 public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
@@ -55,7 +54,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + authenticatedToken)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
@@ -73,7 +72,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .relaxedHTTPSValidation()
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
@@ -86,7 +85,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + forbiddenToken)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(FORBIDDEN.value());
@@ -100,7 +99,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .header(AUTHORIZATION, BEARER + authenticatedToken)
             .body(adminCourtInfoJson)
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
@@ -120,7 +119,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .header(AUTHORIZATION, BEARER + superAdminToken)
             .body(new ObjectMapper().writeValueAsString(EXPECTED_SUPER_ADMIN_COURT_INFO))
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
@@ -139,7 +138,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .body(adminCourtInfoJson)
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
@@ -153,7 +152,7 @@ public class AdminCourtGeneralInfoEndpointTest extends AdminFunctionalTestBase {
             .header(AUTHORIZATION, BEARER + forbiddenToken)
             .body(adminCourtInfoJson)
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + ADMIN_COURT_GENERAL_INFO_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(FORBIDDEN.value());

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtOpeningTimeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtOpeningTimeEndpointTest.java
@@ -26,7 +26,6 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
     private static final String OPENING_TIMES_PATH = "/" + "openingTimes";
     private static final String OPENING_TYPES_PATH = "openingTypes";
     private static final String BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG = "birmingham-civil-and-family-justice-centre";
-    private static final Integer TEST_OPENING_TYPE_ID = 9999;
     private static final String TEST_HOURS = "test hour";
 
     @Test
@@ -36,7 +35,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + authenticatedToken)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
@@ -50,7 +49,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .relaxedHTTPSValidation()
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
@@ -63,7 +62,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + forbiddenToken)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(FORBIDDEN.value());
@@ -71,7 +70,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
 
     @Test
     public void shouldUpdateOpeningTimes() throws JsonProcessingException {
-        final List<OpeningTime> currentOpeningTimes = getCurrentOpeningTimes();
+        final List<OpeningTime> currentOpeningTimes = getCurrentOpeningTimes(BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG);
         final List<OpeningTime> expectedOpeningTimes = updateOpeningTimes(currentOpeningTimes);
         final String json = objectMapper().writeValueAsString(expectedOpeningTimes);
 
@@ -81,7 +80,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .header(AUTHORIZATION, BEARER + authenticatedToken)
             .body(json)
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
@@ -96,7 +95,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .body(getTestOpeningTimeJson())
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
@@ -110,7 +109,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .header(AUTHORIZATION, BEARER + forbiddenToken)
             .body(getTestOpeningTimeJson())
             .when()
-            .put(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(FORBIDDEN.value());
@@ -123,7 +122,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + authenticatedToken)
             .when()
-            .get(COURTS_ENDPOINT + OPENING_TYPES_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + OPENING_TYPES_PATH)
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
@@ -131,13 +130,25 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
         assertThat(openingTypes).hasSizeGreaterThan(1);
     }
 
-    private List<OpeningTime> getCurrentOpeningTimes() {
+    @Test
+    public void shouldRequireATokenWhenGettingAllOpeningTypes() {
+        final var response = given()
+            .relaxedHTTPSValidation()
+            .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
+            .when()
+            .get(ADMIN_COURTS_ENDPOINT + OPENING_TYPES_PATH)
+            .thenReturn();
+
+        assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
+    }
+
+    private List<OpeningTime> getCurrentOpeningTimes(final String slug) {
         final var response = given()
             .relaxedHTTPSValidation()
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + authenticatedToken)
             .when()
-            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .get(ADMIN_COURTS_ENDPOINT + slug + OPENING_TIMES_PATH)
             .thenReturn();
 
         return response.body().jsonPath().getList(".", OpeningTime.class);
@@ -156,7 +167,7 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
                 .collect(toList());
         } else {
             updatedOpeningTimes = new ArrayList<>(openingTimes);
-            updatedOpeningTimes.add(new OpeningTime(TEST_OPENING_TYPE_ID, TEST_HOURS));
+            updatedOpeningTimes.add(new OpeningTime(null, TEST_HOURS));
         }
         return updatedOpeningTimes;
     }

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtOpeningTimeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtOpeningTimeEndpointTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.dts.fact.model.Court;
 import uk.gov.hmcts.dts.fact.model.admin.OpeningTime;
 import uk.gov.hmcts.dts.fact.model.admin.OpeningType;
 import uk.gov.hmcts.dts.fact.util.AdminFunctionalTestBase;
@@ -13,10 +14,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
 import static uk.gov.hmcts.dts.fact.util.TestUtil.*;
 
@@ -27,6 +26,10 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
     private static final String OPENING_TYPES_PATH = "openingTypes";
     private static final String BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG = "birmingham-civil-and-family-justice-centre";
     private static final String TEST_HOURS = "test hour";
+    private static final int BAILIFF_OFFICE_OPEN_TYPE_ID = 5;
+    private static final String BAILIFF_OFFICE_OPEN_TYPE = "Bailiff office open";
+    private static final String BAILIFF_OFFICE_OPEN_TYPE_WELSH = "Oriau agor swyddfa'r Beiliaid";
+    private static final OpeningTime TEST_OPENING_TIME = new OpeningTime(BAILIFF_OFFICE_OPEN_TYPE_ID, TEST_HOURS);
 
     @Test
     public void shouldGetOpeningTimes() {
@@ -69,12 +72,13 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
     }
 
     @Test
-    public void shouldUpdateOpeningTimes() throws JsonProcessingException {
+    public void shouldAddOrRemoveOpeningTimes() throws JsonProcessingException {
+        // Add a new opening time
         final List<OpeningTime> currentOpeningTimes = getCurrentOpeningTimes(BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG);
-        final List<OpeningTime> expectedOpeningTimes = updateOpeningTimes(currentOpeningTimes);
-        final String json = objectMapper().writeValueAsString(expectedOpeningTimes);
+        List<OpeningTime> expectedOpeningTimes = addNewOpeningTime(currentOpeningTimes);
+        String json = objectMapper().writeValueAsString(expectedOpeningTimes);
 
-        final var response = given()
+        var response = given()
             .relaxedHTTPSValidation()
             .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
             .header(AUTHORIZATION, BEARER + authenticatedToken)
@@ -84,7 +88,57 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
             .thenReturn();
 
         assertThat(response.statusCode()).isEqualTo(OK.value());
-        final List<OpeningTime> updatedOpeningTimes = response.body().jsonPath().getList(".", OpeningTime.class);
+        List<OpeningTime> updatedOpeningTimes = response.body().jsonPath().getList(".", OpeningTime.class);
+        assertThat(updatedOpeningTimes).containsExactlyElementsOf(expectedOpeningTimes);
+
+        // Check the standard court endpoint still display the added opening type in English after the opening time update
+        response = given()
+            .relaxedHTTPSValidation()
+            .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
+            .when()
+            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG)
+            .thenReturn();
+
+        assertThat(response.statusCode()).isEqualTo(OK.value());
+
+        Court court = response.as(Court.class);
+        List<uk.gov.hmcts.dts.fact.model.OpeningTime> openingTimes = court.getOpeningTimes();
+        assertThat(openingTimes).hasSizeGreaterThan(1);
+        assertThat(openingTimes.stream()).anyMatch(openingTime -> openingTime.getHours().equals(TEST_HOURS)
+            && openingTime.getType().equals(BAILIFF_OFFICE_OPEN_TYPE));
+
+        // Check the standard court endpoint still display the added opening type in Welsh after the opening time update
+        response = given()
+            .relaxedHTTPSValidation()
+            .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
+            .header(ACCEPT_LANGUAGE, "cy")
+            .when()
+            .get(COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG)
+            .thenReturn();
+
+        assertThat(response.statusCode()).isEqualTo(OK.value());
+
+        court = response.as(Court.class);
+        openingTimes = court.getOpeningTimes();
+        assertThat(openingTimes).hasSizeGreaterThan(1);
+        assertThat(openingTimes.stream()).anyMatch(openingTime -> openingTime.getHours().equals(TEST_HOURS)
+            && openingTime.getType().equals(BAILIFF_OFFICE_OPEN_TYPE_WELSH));
+
+        // Remove the added opening time
+        expectedOpeningTimes = removeOpeningTime(updatedOpeningTimes);
+        json = objectMapper().writeValueAsString(expectedOpeningTimes);
+
+        response = given()
+            .relaxedHTTPSValidation()
+            .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
+            .header(AUTHORIZATION, BEARER + authenticatedToken)
+            .body(json)
+            .when()
+            .put(ADMIN_COURTS_ENDPOINT + BIRMINGHAM_CIVIL_AND_FAMILY_JUSTICE_CENTRE_SLUG + OPENING_TIMES_PATH)
+            .thenReturn();
+
+        assertThat(response.statusCode()).isEqualTo(OK.value());
+        updatedOpeningTimes = response.body().jsonPath().getList(".", OpeningTime.class);
         assertThat(updatedOpeningTimes).containsExactlyElementsOf(expectedOpeningTimes);
     }
 
@@ -154,21 +208,15 @@ public class AdminCourtOpeningTimeEndpointTest extends AdminFunctionalTestBase {
         return response.body().jsonPath().getList(".", OpeningTime.class);
     }
 
-    private List<OpeningTime> updateOpeningTimes(List<OpeningTime> openingTimes) {
-        List<OpeningTime> updatedOpeningTimes;
+    private List<OpeningTime> addNewOpeningTime(List<OpeningTime> openingTimes) {
+        List<OpeningTime> updatedOpeningTimes = new ArrayList<>(openingTimes);
+        updatedOpeningTimes.add(TEST_OPENING_TIME);
+        return updatedOpeningTimes;
+    }
 
-        final boolean testRecordPresent = openingTimes.stream()
-            .map(o -> o.getHours())
-            .anyMatch(o -> o.equals(TEST_HOURS));
-
-        if (testRecordPresent) {
-            updatedOpeningTimes = openingTimes.stream()
-                .filter(o -> !o.getHours().equals(TEST_HOURS))
-                .collect(toList());
-        } else {
-            updatedOpeningTimes = new ArrayList<>(openingTimes);
-            updatedOpeningTimes.add(new OpeningTime(null, TEST_HOURS));
-        }
+    private List<OpeningTime> removeOpeningTime(List<OpeningTime> openingTimes) {
+        List<OpeningTime> updatedOpeningTimes = new ArrayList<>(openingTimes);
+        updatedOpeningTimes.removeIf(time -> time.getHours().equals(TEST_HOURS));
         return updatedOpeningTimes;
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/util/TestUtil.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/util/TestUtil.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public final class TestUtil {
     public static final String COURTS_ENDPOINT = "/courts/";
+    public static final String ADMIN_COURTS_ENDPOINT = "/admin/courts/";
     public static final String BEARER = "Bearer ";
 
     private TestUtil() {

--- a/src/integrationTest/java/uk/gov/hmcts/dts/fact/repositories/OpeningTypeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/dts/fact/repositories/OpeningTypeRepositoryTest.java
@@ -19,7 +19,7 @@ public class OpeningTypeRepositoryTest {
     @Test
     void shouldRetrieveAllOpeningTypes() {
         List<OpeningType> results = openingTypeRepository.findAll();
-        assertThat(results).hasSize(8);
+        assertThat(results).hasSize(12);
         assertThat(results.stream().map(r -> r.getName())).isNotEmpty();
         assertThat(results.stream().map(r -> r.getNameCy())).isNotEmpty();
     }

--- a/src/integrationTest/resources/deprecated/aylesbury-magistrates-court-and-family-court.json
+++ b/src/integrationTest/resources/deprecated/aylesbury-magistrates-court-and-family-court.json
@@ -56,7 +56,7 @@
   ],
   "opening_times": [
     {
-      "description": "Court building open",
+      "description": "Court open",
       "hours": "8.45 am - 4.45 pm"
     }
   ],

--- a/src/main/java/uk/gov/hmcts/dts/fact/config/security/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/config/security/SecurityConfiguration.java
@@ -15,6 +15,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests(a -> a
+                .antMatchers(HttpMethod.GET, "/admin/**").authenticated()
                 .antMatchers(HttpMethod.GET, "/courts/").authenticated()
                 .antMatchers(HttpMethod.GET, "/courts/all").authenticated()
                 .antMatchers(HttpMethod.GET, "/courts/{slug}/*").authenticated()

--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoController.java
@@ -15,7 +15,7 @@ import static uk.gov.hmcts.dts.fact.services.admin.AdminRole.FACT_SUPER_ADMIN;
 
 @RestController
 @RequestMapping(
-    path = "courts/{slug}/generalInfo",
+    path = "/admin/courts/{slug}/generalInfo",
     produces = {MediaType.APPLICATION_JSON_VALUE}
 )
 public class AdminCourtGeneralInfoController {

--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimesController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimesController.java
@@ -18,7 +18,7 @@ import static uk.gov.hmcts.dts.fact.services.admin.AdminRole.FACT_SUPER_ADMIN;
 
 @RestController
 @RequestMapping(
-    path = "courts",
+    path = "/admin/courts",
     produces = {MediaType.APPLICATION_JSON_VALUE}
 )
 public class AdminCourtOpeningTimesController {

--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/OpeningTime.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/OpeningTime.java
@@ -20,8 +20,9 @@ public class OpeningTime {
     @Column(name = "type_cy")
     private String typeCy;
     private String hours;
-    @Column(name = "opening_type_id")
-    private Integer openingTypeId;
+    @OneToOne()
+    @JoinColumn(name = "opening_type_id")
+    private OpeningType openingType;
 
     public OpeningTime(final String type, final String typeCy, final String hours) {
         this.type = type;
@@ -29,8 +30,8 @@ public class OpeningTime {
         this.hours = hours;
     }
 
-    public OpeningTime(final Integer openingTypeId, final String hours) {
-        this.openingTypeId = openingTypeId;
+    public OpeningTime(final OpeningType openingType, final String hours) {
+        this.openingType = openingType;
         this.hours = hours;
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/CourtForDownload.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/CourtForDownload.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.hmcts.dts.fact.entity.AreaOfLaw;
+import uk.gov.hmcts.dts.fact.entity.CourtEmail;
+import uk.gov.hmcts.dts.fact.entity.CourtOpeningTime;
+import uk.gov.hmcts.dts.fact.entity.CourtType;
 import uk.gov.hmcts.dts.fact.entity.Facility;
-import uk.gov.hmcts.dts.fact.entity.*;
 
 import java.text.SimpleDateFormat;
 import java.util.Collection;

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/CourtForDownload.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/CourtForDownload.java
@@ -6,10 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.hmcts.dts.fact.entity.AreaOfLaw;
-import uk.gov.hmcts.dts.fact.entity.CourtEmail;
-import uk.gov.hmcts.dts.fact.entity.CourtOpeningTime;
-import uk.gov.hmcts.dts.fact.entity.CourtType;
 import uk.gov.hmcts.dts.fact.entity.Facility;
+import uk.gov.hmcts.dts.fact.entity.*;
 
 import java.text.SimpleDateFormat;
 import java.util.Collection;
@@ -29,7 +27,7 @@ import static uk.gov.hmcts.dts.fact.util.Utils.NAME_IS_NOT_DX;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(SnakeCaseStrategy.class)
-@SuppressWarnings("PMD.TooManyFields")
+@SuppressWarnings({"PMD.TooManyFields", "PMD.UnnecessaryFullyQualifiedName"})
 public class CourtForDownload {
     private static final String DX = "DX";
     private String name;
@@ -141,6 +139,7 @@ public class CourtForDownload {
     }
 
     private String formatOpeningTime(uk.gov.hmcts.dts.fact.entity.OpeningTime openingTime) {
-        return format("Description: %s, Hours: %s", openingTime.getType(), openingTime.getHours());
+        final String openingType = openingTime.getOpeningType() == null ? openingTime.getType() : openingTime.getOpeningType().getName();
+        return format("Description: %s, Hours: %s", openingType, openingTime.getHours());
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/OpeningTime.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/OpeningTime.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.dts.fact.entity.OpeningType;
 
 import static uk.gov.hmcts.dts.fact.util.Utils.chooseString;
 
@@ -20,7 +21,11 @@ public class OpeningTime {
     private String hours;
 
     public OpeningTime(uk.gov.hmcts.dts.fact.entity.OpeningTime openingTime) {
-        this.type = chooseString(openingTime.getTypeCy(), openingTime.getType());
+        final OpeningType openingType = openingTime.getOpeningType();
+        final String openingTimeDescription = (openingType == null) ? openingTime.getType() : openingType.getName();
+        final String openingTimeDescriptionCy = (openingType == null) ? openingTime.getTypeCy() : openingType.getNameCy();
+
+        this.type = chooseString(openingTimeDescriptionCy, openingTimeDescription);
         this.hours = openingTime.getHours();
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/admin/OpeningTime.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/admin/OpeningTime.java
@@ -14,7 +14,9 @@ public class OpeningTime {
     private String hours;
 
     public OpeningTime(uk.gov.hmcts.dts.fact.entity.OpeningTime openingTime) {
-        this.typeId = openingTime.getOpeningTypeId();
+        if (openingTime.getOpeningType() != null) {
+            this.typeId = openingTime.getOpeningType().getId();
+        }
         this.hours = openingTime.getHours();
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtOpeningTimeService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtOpeningTimeService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dts.fact.services.admin;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.dts.fact.entity.Court;
 import uk.gov.hmcts.dts.fact.entity.CourtOpeningTime;
 import uk.gov.hmcts.dts.fact.exception.NotFoundException;
@@ -13,8 +12,10 @@ import uk.gov.hmcts.dts.fact.repositories.OpeningTypeRepository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 @Service
 public class AdminCourtOpeningTimeService {
@@ -54,7 +55,7 @@ public class AdminCourtOpeningTimeService {
         List<uk.gov.hmcts.dts.fact.entity.OpeningTime> openingTimeEntities = getNewOpeningTimes(openingTimes);
         List<CourtOpeningTime> courtOpeningTimeEntities = getNewCourtOpeningTimes(courtEntity, openingTimeEntities);
 
-        if (CollectionUtils.isEmpty(courtEntity.getCourtOpeningTimes())) {
+        if (courtEntity.getCourtOpeningTimes() == null) {
             courtEntity.setCourtOpeningTimes(courtOpeningTimeEntities);
         } else {
             courtEntity.getCourtOpeningTimes().clear();
@@ -69,10 +70,22 @@ public class AdminCourtOpeningTimeService {
             .collect(toList());
     }
 
+    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops", "PMD.DataflowAnomalyAnalysis"})
     private List<uk.gov.hmcts.dts.fact.entity.OpeningTime> getNewOpeningTimes(final List<OpeningTime> openingTimes) {
-        return openingTimes.stream()
-            .map(o -> new uk.gov.hmcts.dts.fact.entity.OpeningTime(o.getTypeId(), o.getHours()))
-            .collect(toList());
+        final Map<Integer, uk.gov.hmcts.dts.fact.entity.OpeningType> openingTypeMap = getOpeningTypeMap();
+        final List<uk.gov.hmcts.dts.fact.entity.OpeningTime> openingTimeEntities = new ArrayList<>();
+
+        for (OpeningTime openingTime : openingTimes) {
+            final uk.gov.hmcts.dts.fact.entity.OpeningType openingType = openingTypeMap.get(openingTime.getTypeId());
+            openingTimeEntities.add(new uk.gov.hmcts.dts.fact.entity.OpeningTime(openingType, openingTime.getHours()));
+        }
+        return openingTimeEntities;
+    }
+
+    private Map<Integer, uk.gov.hmcts.dts.fact.entity.OpeningType> getOpeningTypeMap() {
+        return openingTypeRepository.findAll()
+            .stream()
+            .collect(toMap(uk.gov.hmcts.dts.fact.entity.OpeningType::getId, type -> type));
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")

--- a/src/main/resources/db/migration/V090__add_extra_court_opening_types.sql
+++ b/src/main/resources/db/migration/V090__add_extra_court_opening_types.sql
@@ -1,0 +1,23 @@
+INSERT INTO public.admin_openingtype(id, name, name_cy)
+VALUES(DEFAULT, 'Magistrates'' Court open', 'Llys Ynadon ar agor');
+
+INSERT INTO public.admin_openingtype(id, name, name_cy)
+VALUES(DEFAULT, 'Crown Court open', 'Llys y Goron ar agor');
+
+INSERT INTO public.admin_openingtype(id, name, name_cy)
+VALUES(DEFAULT, 'Family Court open', 'Llys Teulu ar agor');
+
+INSERT INTO public.admin_openingtype(id, name, name_cy)
+VALUES(DEFAULT, 'County Court open', 'Llys Sirol ar agor');
+
+UPDATE public.search_openingtime
+SET opening_type_id = (
+    SELECT id FROM public.admin_openingtype
+    WHERE name = 'Magistrates'' Court open')
+WHERE type = 'Magistrates'' Court open';
+
+UPDATE public.search_openingtime
+SET opening_type_id = (
+    SELECT id FROM public.admin_openingtype
+    WHERE name = 'Crown Court open')
+WHERE type = 'Crown Court open';

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AdminCourtGeneralInfoController.class)
 @AutoConfigureMockMvc(addFilters = false)
 public class AdminCourtGeneralInfoControllerTest {
-    private static final String BASE_PATH = "/courts/";
+    private static final String BASE_PATH = "/admin/courts/";
     private static final String CHILD_PATH = "/generalInfo";
     private static final String TEST_SLUG = "unknownSlug";
     private static final CourtGeneralInfo COURT_GENERAL_INFO = new CourtGeneralInfo(

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimesControllerTest.java
@@ -26,7 +26,7 @@ import static uk.gov.hmcts.dts.fact.util.TestHelper.getResourceAsJson;
 @WebMvcTest(AdminCourtOpeningTimesController.class)
 @AutoConfigureMockMvc(addFilters = false)
 public class AdminCourtOpeningTimesControllerTest {
-    private static final String BASE_PATH = "/courts/";
+    private static final String BASE_PATH = "/admin/courts/";
     private static final String OPENING_TIMES_PATH = "/" + "openingTimes";
     private static final String OPENING_TYPES_PATH = "openingTypes";
     private static final String TEST_SLUG = "unknownSlug";

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/CourtServiceTest.java
@@ -9,9 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.dts.fact.entity.AreaOfLaw;
-import uk.gov.hmcts.dts.fact.entity.Court;
-import uk.gov.hmcts.dts.fact.entity.ServiceArea;
+import uk.gov.hmcts.dts.fact.entity.*;
 import uk.gov.hmcts.dts.fact.exception.InvalidPostcodeException;
 import uk.gov.hmcts.dts.fact.exception.NotFoundException;
 import uk.gov.hmcts.dts.fact.mapit.MapitData;
@@ -38,7 +36,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
@@ -59,6 +58,8 @@ class CourtServiceTest {
     private static final String IMMIGRATION = "Immigration";
     private static final String EMPLOYMENT = "Employment";
     private static final String GLASGOW_TRIBUNALS_CENTRE = "Glasgow Tribunals Centre";
+    private static final String TEST_TYPE_IN_OPENING_TIME_TABLE = "Test type in opening time";
+    private static final String TEST_TYPE_IN_ADMIN_TABLE = "Test type in opening type";
 
     @Autowired
     private CourtService courtService;
@@ -102,6 +103,42 @@ class CourtServiceTest {
         final Court court = mock(Court.class);
         when(courtRepository.findBySlug(SOME_SLUG)).thenReturn(Optional.of(court));
         assertThat(courtService.getCourtBySlug(SOME_SLUG)).isInstanceOf(uk.gov.hmcts.dts.fact.model.Court.class);
+    }
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private static Stream<Arguments> parametersForOpeningTypeInAdminTableShouldTakePrecedence() {
+        return Stream.of(
+            // Opening type in opening time table only
+            Arguments.of(TEST_TYPE_IN_OPENING_TIME_TABLE, null, TEST_TYPE_IN_OPENING_TIME_TABLE),
+            // Opening type in admin type table only
+            Arguments.of(null, TEST_TYPE_IN_ADMIN_TABLE, TEST_TYPE_IN_ADMIN_TABLE),
+            // Opening type in both opening time and admin type tables
+            Arguments.of(TEST_TYPE_IN_OPENING_TIME_TABLE, TEST_TYPE_IN_ADMIN_TABLE, TEST_TYPE_IN_ADMIN_TABLE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForOpeningTypeInAdminTableShouldTakePrecedence")
+    void openingTypeInAdminTableShouldTakePrecedence(final String typeInOpeningTimeTable, final String typeInAdminTable, final String expectedType) {
+        final OpeningTime openingTime = new OpeningTime();
+        openingTime.setType(typeInOpeningTimeTable);
+        if (typeInAdminTable != null) {
+            openingTime.setOpeningType(new OpeningType(1, typeInAdminTable, null));
+        }
+
+        final CourtOpeningTime courtOpeningTime = mock(CourtOpeningTime.class);
+        when(courtOpeningTime.getOpeningTime()).thenReturn(openingTime);
+        List<CourtOpeningTime> courtOpeningTimes = singletonList(courtOpeningTime);
+
+        final Court court = mock(Court.class);
+        when(court.getCourtOpeningTimes()).thenReturn(courtOpeningTimes);
+        when(courtRepository.findBySlug(SOME_SLUG)).thenReturn(Optional.of(court));
+
+        final uk.gov.hmcts.dts.fact.model.Court result = courtService.getCourtBySlug(SOME_SLUG);
+        assertThat(result).isInstanceOf(uk.gov.hmcts.dts.fact.model.Court.class);
+        final List<uk.gov.hmcts.dts.fact.model.OpeningTime> openingTimes = result.getOpeningTimes();
+        assertThat(openingTimes).hasSize(1);
+        assertThat(openingTimes.get(0).getType()).isEqualTo(expectedType);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtOpeningTimeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtOpeningTimeServiceTest.java
@@ -89,8 +89,9 @@ public class AdminCourtOpeningTimeServiceTest {
 
     @Test
     void shouldUpdateCourtOpeningTimes() {
-        when(court.getCourtOpeningTimes()).thenReturn(COURT_OPENING_TIMES);
         when(courtRepository.findBySlug(COURT_SLUG)).thenReturn(Optional.of(court));
+        when(openingTypeRepository.findAll()).thenReturn(OPENING_TYPES);
+        when(court.getCourtOpeningTimes()).thenReturn(COURT_OPENING_TIMES);
         when(courtRepository.save(court)).thenReturn(court);
 
         assertThat(adminService.updateCourtOpeningTimes(COURT_SLUG, EXPECTED_OPENING_TIMES))


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-408

### Change description ###

- Fix issue where exception is thrown when adding new opening times to courts with no existing opening times
- Update standard court endpoints so that opening type in the admin table is used instead of the opening type in the opening time table.
- Prefix admin court opening types and general info endpoints with “/admin” path

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
