### PR TITLE
CVE-2021-22112-Patch - Updated SpringBoot to 2.3.10.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.3.9.RELEASE'
+  id 'org.springframework.boot' version '2.3.10.RELEASE'
   id 'org.owasp.dependencycheck' version '6.1.6'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'


### PR DESCRIPTION
### Change description ###
Update SpringBoot framework to 2.3.10.RELEASE to bump up SpringSecurity dependency to safe 2.3.9 build


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
