### PR TITLE
FACT-70 - Minor update for comparing court types from admin portal

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -4,18 +4,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
 public class GlobalControllerExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
-    ResponseEntity<String> notFoundExceptionHandler(NotFoundException ex) {
+    ResponseEntity<String> notFoundExceptionHandler(final NotFoundException ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(InvalidPostcodeException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    ResponseEntity<String> invalidPostcodeExceptionHandler(InvalidPostcodeException ex) {
+    @ExceptionHandler({
+        InvalidPostcodeException.class,
+        IllegalArgumentException.class
+    })
+    ResponseEntity<String> invalidPostcodeExceptionHandler(final Exception ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtTypesService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtTypesService.java
@@ -64,7 +64,7 @@ public class AdminCourtTypesService {
 
     protected List<CourtType> saveNewCourtCourtTypes(final Court courtEntity, final List<CourtType> courtTypes) {
 
-        List<uk.gov.hmcts.dts.fact.entity.CourtType> courtTypeEntity = getNewCourtCourtTypesEntity(courtTypes);
+        final List<uk.gov.hmcts.dts.fact.entity.CourtType> courtTypeEntity = getNewCourtCourtTypesEntity(courtTypes);
 
         if (courtEntity.getCourtTypes() == null) {
             courtEntity.setCourtTypes(courtTypeEntity);
@@ -73,11 +73,11 @@ public class AdminCourtTypesService {
             courtEntity.getCourtTypes().addAll(courtTypeEntity);
         }
 
-        Court amendedCourtEntity = mapCourtCode.mapCourtCodesForCourtEntity(courtTypes, courtEntity);
+        final Court amendedCourtEntity = mapCourtCode.mapCourtCodesForCourtEntity(courtTypes, courtEntity);
 
         final Court courtWithUpdatedCourtTypes = courtRepository.save(amendedCourtEntity);
 
-        List<CourtType> returnCourtTypes = courtWithUpdatedCourtTypes.getCourtTypes()
+        final List<CourtType> returnCourtTypes = courtWithUpdatedCourtTypes.getCourtTypes()
             .stream()
             .map(CourtType::new)
             .collect(toList());

--- a/src/main/java/uk/gov/hmcts/dts/fact/util/CourtType.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/util/CourtType.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.dts.fact.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.hmcts.dts.fact.entity.Court;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum CourtType {
+    MAGISTRATES_COURT("Magistrates' Court", c -> c.getMagistrateCode(), (c, v) -> c.setMagistrateCode(v)),
+    CROWN_COURT("Crown Court", c -> c.getNumber(), (c, v) -> c.setNumber(v)),
+    COUNTY_COURT("County Court", c -> c.getCciCode(), (c, v) -> c.setCciCode(v)),
+    FAMILY_COURT("Family Court"),
+    TRIBUNAL("Tribunal");
+
+    private static final Map<String, CourtType> LOOKUP = new ConcurrentHashMap<>();
+
+    private final String name;
+    private Function<Court, Integer> courtCodeFunction;
+    private BiConsumer<Court, Integer> courtCodeConsumer;
+
+    static {
+        Arrays.stream(values())
+            .forEach(t -> LOOKUP.put(t.name.toLowerCase(Locale.getDefault()), t));
+    }
+
+    public Integer getCourtCodeFromEntity(final Court court) {
+        return courtCodeFunction.apply(court);
+    }
+
+    public void setCourtCodeInEntity(final Court court, final Integer code) {
+        courtCodeConsumer.accept(court, code);
+    }
+
+    public static CourtType findByName(final String name) {
+        final String key = name.toLowerCase(Locale.getDefault());
+        if (!LOOKUP.containsKey(key)) {
+            throw new IllegalArgumentException("Unknown court type: " + name);
+        }
+        return LOOKUP.get(key);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/dts/fact/util/MapCourtCode.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/util/MapCourtCode.java
@@ -7,51 +7,26 @@ import uk.gov.hmcts.dts.fact.model.admin.CourtType;
 import java.util.List;
 
 @Component
+@SuppressWarnings("PMD.LawOfDemeter")
 public class MapCourtCode {
 
     public Court mapCourtCodesForCourtEntity(final List<CourtType> courtTypes, final Court courtEntity) {
-
-        //set court codes in Court Entity
-        for (final CourtType courtType : courtTypes) {
-
-            switch (courtType.getName()) {
-                case "Magistrates' Court":
-                    courtEntity.setMagistrateCode(courtType.getCode());
-                    break;
-                case "County Court":
-                    courtEntity.setCciCode(courtType.getCode());
-                    break;
-                case "Crown Court":
-                    courtEntity.setNumber(courtType.getCode());
-                    break;
-                default:
-                    break;
+        for (final CourtType c : courtTypes) {
+            final uk.gov.hmcts.dts.fact.util.CourtType courtType = uk.gov.hmcts.dts.fact.util.CourtType.findByName(c.getName());
+            if (courtType.getCourtCodeConsumer() != null) {
+                courtType.setCourtCodeInEntity(courtEntity, c.getCode());
             }
         }
-
         return courtEntity;
     }
 
     public List<CourtType> mapCourtCodesForCourtTypeModel(final List<CourtType> courtTypes, final Court court) {
-        for (final CourtType courtType : courtTypes) {
-
-            switch (courtType.getName()) {
-                case "Magistrates' Court":
-                    courtType.setCode(court.getMagistrateCode());
-                    break;
-                case "County Court":
-                    courtType.setCode(court.getCciCode());
-                    break;
-                case "Crown Court":
-                    courtType.setCode(court.getNumber());
-                    break;
-                default:
-                    break;
+        for (final CourtType c : courtTypes) {
+            final uk.gov.hmcts.dts.fact.util.CourtType courtType = uk.gov.hmcts.dts.fact.util.CourtType.findByName(c.getName());
+            if (courtType.getCourtCodeFunction() != null) {
+                c.setCode(courtType.getCourtCodeFromEntity(court));
             }
         }
-
         return courtTypes;
-
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesControllerTest.java
@@ -33,6 +33,7 @@ public class AdminCourtTypesControllerTest {
     private static final String CHILD_PATH_ALL = "courtTypes/all";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String TEST_COURT_TYPES_PATH = "court-types.json";
+    private static final String TEST_UNKNOWN_COURT_TYPE_MESSAGE = "Court type not found";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -40,8 +41,6 @@ public class AdminCourtTypesControllerTest {
 
     @MockBean
     private AdminCourtTypesService adminService;
-
-
 
     @Test
     void shouldReturnAllCourtTypes() throws Exception {
@@ -54,8 +53,6 @@ public class AdminCourtTypesControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
     }
-
-
 
     @Test
     void shouldReturnCourtCourtTypes() throws Exception {
@@ -109,8 +106,18 @@ public class AdminCourtTypesControllerTest {
             .andExpect(content().string("Not found: " + TEST_SLUG));
     }
 
+    @Test
+    void updateCourtCourtTypesShouldReturnBadRequestForUnknownCourtType() throws Exception {
+        final String expectedJson = getResourceAsJson(TEST_COURT_TYPES_PATH);
+        final List<CourtType> courtTypes = asList(OBJECT_MAPPER.readValue(expectedJson, CourtType[].class));
 
+        when(adminService.updateCourtCourtTypes(TEST_SLUG, courtTypes)).thenThrow(new IllegalArgumentException(TEST_UNKNOWN_COURT_TYPE_MESSAGE));
 
-
-
+        mockMvc.perform(put(BASE_PATH + TEST_SLUG + CHILD_PATH)
+                            .content(expectedJson)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(TEST_UNKNOWN_COURT_TYPE_MESSAGE));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtTypeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtTypeServiceTest.java
@@ -36,6 +36,7 @@ public class AdminCourtTypeServiceTest {
     private static final List<CourtType> COURT_TYPES = new ArrayList<>();
     private static final String COURT_SLUG = "some slug";
     private static final String NOT_FOUND = "Not found: ";
+    private static final String TEST_MESSAGE = "Test Message";
 
     private static final List<CourtType> EXPECTED_COURT_TYPES_ENTITY = Arrays.asList(
         new CourtType(1,"test1"),
@@ -125,5 +126,16 @@ public class AdminCourtTypeServiceTest {
         assertThatThrownBy(() -> adminCourtTypesService.updateCourtCourtTypes(COURT_SLUG, any()))
             .isInstanceOf(NotFoundException.class)
             .hasMessage(NOT_FOUND + COURT_SLUG);
+    }
+
+    @Test
+    void shouldReturnIllegalArgumentForUnknownCourtType() {
+        when(court.getCourtTypes()).thenReturn(COURT_TYPES);
+        when(courtRepository.findBySlug(COURT_SLUG)).thenReturn(Optional.of(court));
+        when(mapCourtCode.mapCourtCodesForCourtEntity(anyList(), any())).thenThrow(new IllegalArgumentException(TEST_MESSAGE));
+
+        assertThatThrownBy(() -> adminCourtTypesService.updateCourtCourtTypes(COURT_SLUG, EXPECTED_COURT_TYPES))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(TEST_MESSAGE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/util/MapCourtCodeTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/util/MapCourtCodeTest.java
@@ -1,44 +1,85 @@
 package uk.gov.hmcts.dts.fact.util;
 
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.dts.fact.entity.Court;
 import uk.gov.hmcts.dts.fact.model.admin.CourtType;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MapCourtCodeTest {
 
+    private static final String UNKNOWN_COURT_TYPE_PREFIX = "Unknown court type: ";
+    private static final String UNKNOWN_COURT_TYPE = "Any type";
 
-    private final MapCourtCode mapCourtCode = new MapCourtCode();
-
-
-
-    private static final List<CourtType>  COURT_TYPES = Arrays.asList(
+    private static final List<CourtType> COURT_TYPES = Arrays.asList(
         new CourtType(1, "Magistrates' Court", 100),
         new CourtType(2,"County Court",101),
         new CourtType(3, "Crown Court",102)
     );
 
+    private static final List<CourtType>  INCORRECT_COURT_TYPES = Collections.singletonList(
+        new CourtType(1, UNKNOWN_COURT_TYPE, 100)
+    );
 
-    private final Court court = new Court();
-    private final Court courtReturn = mapCourtCode.mapCourtCodesForCourtEntity(COURT_TYPES,court);
+    private final MapCourtCode mapCourtCode = new MapCourtCode();
+    private Court court;
 
-
+    @BeforeEach
+    void initialise() {
+        court = new Court();
+    }
 
     @Test
     void shouldReturnMapCourtCodesForCourtEntity() {
-
-        assertEquals(court, mapCourtCode.mapCourtCodesForCourtEntity(COURT_TYPES,court));
+        assertEquals(court, mapCourtCode.mapCourtCodesForCourtEntity(COURT_TYPES, court));
     }
-
 
     @Test
     void shouldMapCourtCodesForCourtTypeModel() {
-
-        assertEquals(COURT_TYPES, mapCourtCode.mapCourtCodesForCourtTypeModel(COURT_TYPES,courtReturn));
+        final Court courtReturn = mapCourtCode.mapCourtCodesForCourtEntity(COURT_TYPES, court);
+        assertEquals(COURT_TYPES, mapCourtCode.mapCourtCodesForCourtTypeModel(COURT_TYPES, courtReturn));
     }
 
+    @Test
+    void shouldThrowExceptionWhenMappingCodeForCourtEntityForUnknownCourtType() {
+        assertThatThrownBy(() -> mapCourtCode.mapCourtCodesForCourtEntity(INCORRECT_COURT_TYPES, court))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(UNKNOWN_COURT_TYPE_PREFIX + UNKNOWN_COURT_TYPE);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenMappingCodeForCourtTypeModelForUnknownCourtType() {
+        assertThatThrownBy(() -> mapCourtCode.mapCourtCodesForCourtTypeModel(INCORRECT_COURT_TYPES, court))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(UNKNOWN_COURT_TYPE_PREFIX + UNKNOWN_COURT_TYPE);
+    }
+
+    @Test
+    void shouldNotUpdateCourtCodeForTribunal() {
+        List<CourtType> courtTypes = Collections.singletonList(new CourtType(1, "Tribunal", 100));
+        mapCourtCode.mapCourtCodesForCourtEntity(courtTypes, court);
+        assertNullCourtCode(court);
+    }
+
+    @Test
+    void shouldNotUpdateCourtCodeForFamilyCourt() {
+        List<CourtType> courtTypes = Collections.singletonList(new CourtType(1, "Family Court", 100));
+        mapCourtCode.mapCourtCodesForCourtTypeModel(courtTypes, court);
+        assertNullCourtCode(court);
+    }
+
+    private void assertNullCourtCode(final Court court) {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(court.getMagistrateCode()).isNull();
+        softly.assertThat(court.getCciCode()).isNull();
+        softly.assertThat(court.getNumber()).isNull();
+        softly.assertAll();
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-70

### Change description ###

Minor update for comparing court types from admin portal. Store court types in enum for comparison with inout from admin portal and throw error if not found.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
