### PR TITLE
CVE-2021-22118-Patch - Upgraded SpringBoot to 2.3.11.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.3.10.RELEASE'
+  id 'org.springframework.boot' version '2.3.11.RELEASE'
   id 'org.owasp.dependencycheck' version '6.1.6'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'


### PR DESCRIPTION
### Change description ###
Upgraded to SpringBoot 2.3.11.RELEASE due to CVE-2021-22118 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22118


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
