### PR TITLE
FACT-188 Fix bug in local authority duplication check to use correct integer equality.

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/list/AdminLocalAuthorityService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/list/AdminLocalAuthorityService.java
@@ -52,7 +52,7 @@ public class AdminLocalAuthorityService {
         List<uk.gov.hmcts.dts.fact.entity.LocalAuthority> existingLocalAuthorities = localAuthorityRepository.findByName(localAuthorityName);
 
         if (!existingLocalAuthorities.isEmpty()
-            && existingLocalAuthorities.stream().anyMatch(la -> la.getId() != localAuthorityId)) {
+            && existingLocalAuthorities.stream().anyMatch(la -> !la.getId().equals(localAuthorityId))) {
             throw new DuplicatedListItemException("Local Authority already exists: " + localAuthorityName);
         }
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FACT-188

Fix bug in local authority duplication check to use correct integer equality.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
