### PR TITLE
FACT-783 Remove redundant GET local authorities endpoint from edit court API.

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtLocalAuthoritiesEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtLocalAuthoritiesEndpointTest.java
@@ -24,7 +24,6 @@ public class AdminCourtLocalAuthoritiesEndpointTest extends AdminFunctionalTestB
 
     private static final String ADMIN_COURTS_ENDPOINT = "/admin/courts/";
     private static final String LOCAL_AUTHORITIES_PATH = "localAuthorities";
-    private static final String ALL_LOCAL_AUTHORITIES_FULL_PATH = ADMIN_COURTS_ENDPOINT + LOCAL_AUTHORITIES_PATH;
     private static final String AYLESBURY_COUNTY_COURT_AND_FAMILY_COURT_SLUG = "aylesbury-county-court-and-family-court/";
     private static final String AYLESBURY_COUNTY_COURT_AND_FAMILY_COURT_AREAS_OF_LAW = "Money claims/";
 
@@ -33,37 +32,6 @@ public class AdminCourtLocalAuthoritiesEndpointTest extends AdminFunctionalTestB
     //changed local authority to existing one on database.
     private static final String TEST = "Barnet Borough Council";
     private static final int TEST_ID = 397_243;
-
-
-
-    @Test
-    public void returnAllLocalAuthorities() {
-        final var response = doGetRequest(
-            ALL_LOCAL_AUTHORITIES_FULL_PATH,
-            Map.of(AUTHORIZATION, BEARER + authenticatedToken)
-        );
-        assertThat(response.statusCode()).isEqualTo(OK.value());
-
-        final List<LocalAuthority> localAuthorities = response.body().jsonPath().getList(".", LocalAuthority.class);
-        assertThat(localAuthorities).hasSizeGreaterThan(1);
-
-    }
-
-    @Test
-    public void shouldRequireATokenWhenGettingLocalAuthorities() {
-        final var response = doGetRequest(ALL_LOCAL_AUTHORITIES_FULL_PATH);
-        assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED.value());
-    }
-
-    @Test
-    public void shouldBeForbiddenForGettingLocalAuthorities() {
-        final var response = doGetRequest(
-            ALL_LOCAL_AUTHORITIES_FULL_PATH,
-            Map.of(AUTHORIZATION, BEARER + forbiddenToken)
-        );
-        assertThat(response.statusCode()).isEqualTo(FORBIDDEN.value());
-    }
-
 
     @Test
     public void returnLocalAuthoritiesForTheCourtAsPerTheAreasOfLaw() {
@@ -75,7 +43,6 @@ public class AdminCourtLocalAuthoritiesEndpointTest extends AdminFunctionalTestB
 
         final List<LocalAuthority> localAuthorities = response.body().jsonPath().getList(".", LocalAuthority.class);
         assertThat(localAuthorities).hasSizeGreaterThan(1);
-
     }
 
     @Test
@@ -139,7 +106,6 @@ public class AdminCourtLocalAuthoritiesEndpointTest extends AdminFunctionalTestB
         assertThat(response.statusCode()).isEqualTo(FORBIDDEN.value());
     }
 
-
     private List<LocalAuthority> getCurrentLocalAuthorities() {
         final var response = doGetRequest(
             AYLESBURY_COURT_LOCAL_AUTHORITIES_AREAS_OF_LAW_PATH,
@@ -167,6 +133,4 @@ public class AdminCourtLocalAuthoritiesEndpointTest extends AdminFunctionalTestB
         );
         return objectMapper().writeValueAsString(localAuthorities);
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesController.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesController.java
@@ -28,14 +28,6 @@ public class AdminCourtLocalAuthoritiesController {
         this.adminCourtLocalAuthoritiesService = adminService;
     }
 
-    //returns all local authorities
-    @GetMapping(path = "/localAuthorities")
-    @ApiOperation("Return all local authorities")
-    @Role({FACT_ADMIN, FACT_SUPER_ADMIN})
-    public ResponseEntity<List<LocalAuthority>> getAllLocalAuthorities() {
-        return ok(adminCourtLocalAuthoritiesService.getAllLocalAuthorities());
-    }
-
     //returns local authorities for a court by passing in a court slug ,area of law and returning local authorities list
     @GetMapping(path = "/{slug}/{areaOfLaw}/localAuthorities")
     @ApiOperation("Find a courts local authorities by slug")

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtLocalAuthoritiesService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtLocalAuthoritiesService.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.dts.fact.exception.NotFoundException;
 import uk.gov.hmcts.dts.fact.model.admin.LocalAuthority;
 import uk.gov.hmcts.dts.fact.repositories.CourtLocalAuthorityAreaOfLawRepository;
 import uk.gov.hmcts.dts.fact.repositories.CourtRepository;
-import uk.gov.hmcts.dts.fact.repositories.LocalAuthorityRepository;
 
 import java.util.List;
 
@@ -19,23 +18,13 @@ import static java.util.stream.Collectors.toList;
 @Service
 public class AdminCourtLocalAuthoritiesService {
 
-    private final LocalAuthorityRepository localAuthorityRepository;
     private final CourtRepository courtRepository;
     private final CourtLocalAuthorityAreaOfLawRepository courtLocalAuthorityAreaOfLawRepository;
 
-
     @Autowired
-    public AdminCourtLocalAuthoritiesService(final LocalAuthorityRepository localAuthorityRepository, final CourtRepository courtRepository, final CourtLocalAuthorityAreaOfLawRepository courtLocalAuthorityAreaOfLawRepository) {
-        this.localAuthorityRepository = localAuthorityRepository;
+    public AdminCourtLocalAuthoritiesService(final CourtRepository courtRepository, final CourtLocalAuthorityAreaOfLawRepository courtLocalAuthorityAreaOfLawRepository) {
         this.courtRepository = courtRepository;
         this.courtLocalAuthorityAreaOfLawRepository = courtLocalAuthorityAreaOfLawRepository;
-    }
-
-    public List<LocalAuthority> getAllLocalAuthorities() {
-        return localAuthorityRepository.findAll()
-            .stream()
-            .map(LocalAuthority::new)
-            .collect(toList());
     }
 
     public List<LocalAuthority> getCourtLocalAuthoritiesBySlugAndAreaOfLaw(final String slug, final String areaOfLaw) {

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
@@ -27,10 +27,8 @@ import static uk.gov.hmcts.dts.fact.util.TestHelper.getResourceAsJson;
 
 public class AdminCourtLocalAuthoritiesControllerTest {
 
-
     private static final String BASE_PATH = "/admin/courts/";
     private static final String CHILD_PATH = "/localAuthorities";
-    private static final String CHILD_PATH_ALL = "localAuthorities";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String TEST_AREA_OF_LAW = "AreaOfLaw";
     private static final String SLASH = "/";
@@ -44,18 +42,6 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
     @MockBean
     private AdminCourtLocalAuthoritiesService adminService;
-
-    @Test
-    void shouldReturnAllLocalAuthorities() throws Exception {
-        final String expectedJson = getResourceAsJson(TEST_LOCAL_AUTHORITIES_PATH);
-        final List<LocalAuthority> localAuthorities = asList(OBJECT_MAPPER.readValue(expectedJson, LocalAuthority[].class));
-
-        when(adminService.getAllLocalAuthorities()).thenReturn(localAuthorities);
-
-        mockMvc.perform(get(BASE_PATH + CHILD_PATH_ALL))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expectedJson));
-    }
 
     @Test
     void shouldReturnCourtLocalAuthorities() throws Exception {
@@ -146,6 +132,4 @@ public class AdminCourtLocalAuthoritiesControllerTest {
             .andExpect(status().isBadRequest())
             .andExpect(content().string(TEST_UNKNOWN_COURT_TYPE_MESSAGE));
     }
-
-
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtLocalAuthoritiesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtLocalAuthoritiesServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.dts.fact.entity.*;
 import uk.gov.hmcts.dts.fact.exception.NotFoundException;
 import uk.gov.hmcts.dts.fact.repositories.CourtLocalAuthorityAreaOfLawRepository;
 import uk.gov.hmcts.dts.fact.repositories.CourtRepository;
-import uk.gov.hmcts.dts.fact.repositories.LocalAuthorityRepository;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = AdminCourtLocalAuthoritiesService.class)
 public class AdminCourtLocalAuthoritiesServiceTest {
 
-
     private static final int LOCAL_AUTHORITIES_COUNT = 3;
     private static final List<CourtLocalAuthorityAreaOfLaw> COURT_LOCAL_AUTHORITIES = new ArrayList<>();
     private static final List<AreaOfLaw> COURT_AREAS_OF_LAW = new ArrayList<>();
@@ -39,21 +37,10 @@ public class AdminCourtLocalAuthoritiesServiceTest {
     private static final String NON_EXISTENT_AREA_OF_LAW = "Non existent area of law";
     private static final String NOT_FOUND = "Not found: ";
 
-    private static final List<LocalAuthority> EXPECTED_LOCAL_AUTHORITIES_ENTITY = Arrays.asList(
-        new LocalAuthority(1,"test1"),
-        new LocalAuthority(2,"test2"),
-        new LocalAuthority(3,"test3")
-    );
-
-
     private static final List<uk.gov.hmcts.dts.fact.model.admin.LocalAuthority> EXPECTED_COURT_LOCAL_AUTHORITIES = Arrays.asList(
         new uk.gov.hmcts.dts.fact.model.admin.LocalAuthority(1,"localAuthority1"),
         new uk.gov.hmcts.dts.fact.model.admin.LocalAuthority(2,"localAuthority2"),
         new uk.gov.hmcts.dts.fact.model.admin.LocalAuthority(3,"localAuthority3"));
-
-
-    @MockBean
-    private LocalAuthorityRepository localAuthorityRepository;
 
     @MockBean
     private CourtRepository courtRepository;
@@ -106,17 +93,6 @@ public class AdminCourtLocalAuthoritiesServiceTest {
         COURT_LOCAL_AUTHORITIES.add(courtLocalAuthorityAreaOfLaw1);
         COURT_LOCAL_AUTHORITIES.add(courtLocalAuthorityAreaOfLaw2);
         COURT_LOCAL_AUTHORITIES.add(courtLocalAuthorityAreaOfLaw3);
-
-    }
-
-    @Test
-    void shouldReturnAllLocalAuthorities() {
-        when(localAuthorityRepository.findAll()).thenReturn(EXPECTED_LOCAL_AUTHORITIES_ENTITY);
-
-        assertThat(adminCourtLocalAuthoritiesService.getAllLocalAuthorities())
-            .hasSize(LOCAL_AUTHORITIES_COUNT)
-            .first()
-            .isInstanceOf(uk.gov.hmcts.dts.fact.model.admin.LocalAuthority.class);
     }
 
     @Test
@@ -130,7 +106,6 @@ public class AdminCourtLocalAuthoritiesServiceTest {
             .isInstanceOf(uk.gov.hmcts.dts.fact.model.admin.LocalAuthority.class);
     }
 
-
     @Test
     void shouldReturnNotFoundWhenRetrievingCourtLocalAuthoritiesForNonExistentCourt() {
         when(courtRepository.findBySlug(COURT_SLUG)).thenReturn(Optional.empty());
@@ -139,7 +114,6 @@ public class AdminCourtLocalAuthoritiesServiceTest {
             .isInstanceOf(NotFoundException.class)
             .hasMessage(NOT_FOUND + COURT_SLUG);
     }
-
 
     @Test
     void shouldUpdateCourtLocalAuthorities() {
@@ -174,7 +148,4 @@ public class AdminCourtLocalAuthoritiesServiceTest {
             .isInstanceOf(NotFoundException.class)
             .hasMessage(NOT_FOUND + NON_EXISTENT_AREA_OF_LAW);
     }
-
-
-
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FACT-783

Remove redundant GET local authorities endpoint from edit court API. This now resides in the 'list' API.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
