### PR TITLE
FACT-842 - Add money claims area of law to Taunton County Court and Isle of Wight Combined Court

### DIFF
--- a/src/main/resources/db/migration/V118__add_money_claims_to_courts.sql
+++ b/src/main/resources/db/migration/V118__add_money_claims_to_courts.sql
@@ -1,0 +1,10 @@
+--- FACT-842, FAC-843 ---
+INSERT INTO public.search_courtareaoflaw(area_of_law_id, court_id, single_point_of_entry)
+VALUES((SELECT id FROM public.search_areaoflaw WHERE name = 'Money claims'),
+       (SELECT id FROM public.search_court WHERE slug = 'taunton-crown-county-and-family-court'),
+       false
+      ),
+      ((SELECT id FROM public.search_areaoflaw WHERE name = 'Money claims'),
+       (SELECT id FROM public.search_court WHERE slug = 'isle-of-wight-combined-court'),
+       false
+      );


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-842
https://tools.hmcts.net/jira/browse/FACT-843

### Change description ###

Add money claims area of law to Taunton County Court and Isle of Wight Combined Court

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
