### PR TITLE
FACT-881 - Move Financial Remedy and Business and Property into area of law table

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/AreaOfLaw.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/AreaOfLaw.java
@@ -24,6 +24,10 @@ public class AreaOfLaw {
     private String externalLinkDescription;
     @Column(name = "external_link_desc_cy")
     private String externalLinkDescriptionCy;
+    @Column(name = "alt_name")
+    private String altName;
+    @Column(name = "alt_name_cy")
+    private String altNameCy;
     @Column(name = "display_name")
     private String displayName;
     @Column(name = "display_name_cy")

--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
@@ -119,6 +119,8 @@ public class Court {
     }
 
     public boolean isInPerson() {
+        // The in-person table does not contains all courts. So if a court does not exist in the in-person table (i.e. imPerson = null),
+        // it will be considered an in-person court so the FaCT front-end can display the court page using relevant template.
         return inPerson == null || inPerson.getIsInPerson();
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
@@ -117,4 +117,8 @@ public class Court {
             .sorted(comparing(AreaOfLaw::getName))
             .collect(Collectors.toList());
     }
+
+    public boolean isInPerson() {
+        return inPerson == null || inPerson.getIsInPerson();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/AreaOfLaw.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/AreaOfLaw.java
@@ -29,4 +29,18 @@ public class AreaOfLaw {
         this.displayName = chooseString(areaOfLaw.getDisplayNameCy(), areaOfLaw.getDisplayName());
         this.displayExternalLink = areaOfLaw.getDisplayExternalLink();
     }
+
+    public AreaOfLaw(uk.gov.hmcts.dts.fact.entity.AreaOfLaw areaOfLaw, final boolean isInPerson) {
+        this.name = areaOfLaw.getName();
+        this.externalLink = chooseString(areaOfLaw.getExternalLinkCy(), areaOfLaw.getExternalLink());
+        this.externalLinkDescription = chooseString(areaOfLaw.getExternalLinkDescriptionCy(), areaOfLaw.getExternalLinkDescription());
+        this.displayName = constructDisplayName(areaOfLaw, isInPerson);
+        this.displayExternalLink = areaOfLaw.getDisplayExternalLink();
+    }
+
+    private String constructDisplayName(final uk.gov.hmcts.dts.fact.entity.AreaOfLaw areaOfLaw, final boolean isInPerson) {
+        return isInPerson
+            ? chooseString(areaOfLaw.getAltNameCy(), areaOfLaw.getAltName())
+            : chooseString(areaOfLaw.getDisplayNameCy(), areaOfLaw.getDisplayName());
+    }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/Court.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/Court.java
@@ -88,7 +88,7 @@ public class Court {
         this.crownLocationCode = courtEntity.getNumber();
         this.countyLocationCode = courtEntity.getCciCode();
         this.magistratesLocationCode = courtEntity.getMagistrateCode();
-        this.areasOfLaw = getAreasOfLaw(courtEntity);
+        this.areasOfLaw = getAreasOfLaw(courtEntity, courtEntity.isInPerson());
         final List<uk.gov.hmcts.dts.fact.entity.Contact> contacts = getContactEntities(courtEntity);
         this.contacts = getContacts(contacts);
         this.courtTypes = courtEntity.getCourtTypes().stream().map(CourtType::getName).collect(toList());
@@ -100,7 +100,7 @@ public class Court {
         this.gbs = courtEntity.getGbs();
         this.dxNumbers = getDxNumbers(contacts);
         this.serviceAreas = courtEntity.getServiceAreas() == null ? emptyList() : getServiceAreas(courtEntity);
-        this.inPerson = courtEntity.getInPerson() == null || courtEntity.getInPerson().getIsInPerson();
+        this.inPerson = courtEntity.isInPerson();
         this.accessScheme = courtEntity.getInPerson() == null ? null : courtEntity.getInPerson().getAccessScheme();
         this.additionalLinks = getAdditionalLink(courtEntity);
     }
@@ -114,11 +114,11 @@ public class Court {
             .collect(toList());
     }
 
-    private List<AreaOfLaw> getAreasOfLaw(final uk.gov.hmcts.dts.fact.entity.Court courtEntity) {
+    private List<AreaOfLaw> getAreasOfLaw(final uk.gov.hmcts.dts.fact.entity.Court courtEntity, final boolean isInPerson) {
         return courtEntity.getAreasOfLaw()
             .stream()
             .map(areaOfLaw -> {
-                AreaOfLaw areaOfLawObj = new AreaOfLaw(areaOfLaw);
+                AreaOfLaw areaOfLawObj = new AreaOfLaw(areaOfLaw, isInPerson);
                 areaOfLawObj.setExternalLink(decodeUrlFromString(areaOfLawObj.getExternalLink()));
                 return areaOfLawObj;
             })

--- a/src/main/resources/db/migration/V122__make_additional_link_per_court.sql
+++ b/src/main/resources/db/migration/V122__make_additional_link_per_court.sql
@@ -1,0 +1,41 @@
+-- Drop the records for Breathing Space
+
+DELETE FROM public.search_courtadditionallink
+WHERE additional_link_id IN (
+    SELECT id FROM public.search_additionallink
+    WHERE description = 'Breathing Space'
+);
+
+DELETE FROM public.search_additionallink
+WHERE description = 'Breathing Space';
+
+
+-- Re-add the records for Breathing Space so the Additional Link record is unique for each court
+
+DO $$
+    DECLARE
+        temp_court_id integer;
+    BEGIN
+        -- Add breathing space additional link to all active County Courts
+        FOR temp_court_id IN SELECT c.id FROM public.search_court c
+                                 INNER JOIN public.search_courtcourttype cct ON c.id = cct.court_id
+                                 INNER JOIN public.search_courttype ct ON cct.court_type_id = ct.id
+                             WHERE c.displayed = true AND ct.name = 'County Court'
+                                 AND NOT c.id IN (SELECT court_id FROM public.search_inperson
+                                                  WHERE is_in_person = false)
+        LOOP
+            INSERT INTO public.search_additionallink(url, description, description_cy, location_id)
+            VALUES ('https://www.gov.uk/guidance/debt-respite-breathing-space-scheme-creditors-responsibilities-to-the-court',
+                    'Breathing Space',
+                    'Gofod Anadlu',
+                    (SELECT id FROM public.admin_sidebarlocation WHERE name = 'Find out more about')
+                   );
+
+            INSERT INTO public.search_courtadditionallink(court_id, additional_link_id, sort)
+            VALUES (temp_court_id,
+                    (SELECT id FROM public.search_additionallink ORDER BY id DESC LIMIT 1),
+                    0
+                   );
+        END LOOP;
+    END;
+$$;

--- a/src/main/resources/db/migration/V123__move_additional_links_to_area_of_law_table.sql
+++ b/src/main/resources/db/migration/V123__move_additional_links_to_area_of_law_table.sql
@@ -1,0 +1,86 @@
+-- Copy existing display_name and display_name_cy data into the alt_name and alt_name_cy columns so these columns will be used to display for in-person court in the front-end
+
+UPDATE public.search_areaoflaw
+SET alt_name = display_name
+WHERE display_name IS NOT NULL
+  AND alt_name IS NULL;
+
+UPDATE public.search_areaoflaw
+SET alt_name_cy = display_name_cy
+WHERE display_name_cy IS NOT NULL
+  AND alt_name_cy IS NULL;
+
+--- Add Financial Remedy to areaoflaw and courtareaoflaw tables
+
+INSERT INTO public.search_areaoflaw(name, external_link, alt_name_cy, display_name, display_name_cy)
+VALUES ('Financial Remedy',
+        'https://www.gov.uk/money-property-when-relationship-ends',
+        'Rhwymedi Ariannol',
+        'If you are making an application to settle your finances following a divorce (Financial Remedy), please refer to the guidance found here',
+        'Os ydych chi’n gwneud cais i setlo eich materion ariannol yn dilyn ysgariad (Rhwymedi Ariannol), cyfeiriwch at y cyfarwyddyd sydd ar gael yma'
+       );
+
+DO $$
+    DECLARE
+        temp_area_of_law_id integer;
+    BEGIN
+        SELECT id INTO temp_area_of_law_id
+        FROM public.search_areaoflaw
+        ORDER BY id DESC LIMIT 1;
+
+        INSERT INTO public.search_courtareaoflaw(area_of_law_id, court_id, single_point_of_entry)
+        VALUES (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'central-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'birmingham-civil-and-family-justice-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'nottingham-county-court-and-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'newport-south-wales-county-court-and-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'swansea-civil-justice-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'liverpool-civil-and-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'sheffield-combined-court-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'newcastle-civil-family-courts-and-tribunals-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'leeds-combined-court-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'medway-county-court-and-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'manchester-civil-justice-centre-civil-and-family-courts'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'peterborough-combined-court-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'oxford-combined-court-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'bristol-civil-and-family-justice-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'bournemouth-and-poole-county-court-and-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'plymouth-combined-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'wrexham-county-and-family-court'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'preston-crown-court-and-family-court-sessions-house'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'bury-st-edmunds-regional-divorce-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'divorce-service-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'newport-south-wales-regional-divorce-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'north-west-regional-divorce-centre'), false),
+               (temp_area_of_law_id, (SELECT id FROM public.search_court WHERE slug = 'south-west-regional-divorce-centre'), false);
+    END
+$$;
+
+--- Add Business and Property to areaoflaw and courtareaoflaw tables
+
+INSERT INTO public.search_areaoflaw(name, external_link, alt_name_cy, display_name_cy)
+VALUES ('Business and Property',
+        'https://www.judiciary.uk/you-and-the-judiciary/going-to-court/high-court/courts-of-the-chancery-division/the-business-and-property-courts-in-birmingham',
+        'Busnes ac Eiddo',
+        'Busnes ac Eiddo'
+       );
+
+INSERT INTO public.search_courtareaoflaw(area_of_law_id, court_id, single_point_of_entry)
+VALUES ((SELECT id FROM public.search_areaoflaw ORDER BY id DESC LIMIT 1),
+        (SELECT id FROM public.search_court WHERE slug = 'birmingham-civil-and-family-justice-centre'),
+        false
+       );
+
+-- Remove Financial Remedy and Business and Property from additional link tables
+
+DELETE FROM public.search_courtadditionallink
+WHERE additional_link_id IN (
+    SELECT id FROM public.search_additionallink
+    WHERE url = 'https://www.gov.uk/money-property-when-relationship-ends'
+        OR description = 'Business and Property'
+    );
+
+DELETE FROM public.search_additionallink
+WHERE url = 'https://www.gov.uk/money-property-when-relationship-ends'
+   OR description = 'Business and Property';
+
+

--- a/src/test/java/uk/gov/hmcts/dts/fact/entity/CourtTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/entity/CourtTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.dts.fact.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CourtTest {
+    @Test
+    void testIsInPerson() {
+        final Court court = new Court();
+        court.setInPerson(null);
+        assertThat(court.isInPerson()).isTrue();
+
+        final InPerson inPerson = new InPerson();
+        inPerson.setIsInPerson(true);
+        court.setInPerson(inPerson);
+        assertThat(court.isInPerson()).isTrue();
+
+        inPerson.setIsInPerson(false);
+        court.setInPerson(inPerson);
+        assertThat(court.isInPerson()).isFalse();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/dts/fact/model/AreaOfLawTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/model/AreaOfLawTest.java
@@ -7,6 +7,7 @@ import org.springframework.context.i18n.LocaleContextHolder;
 
 import java.util.Locale;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AreaOfLawTest {
@@ -23,6 +24,8 @@ class AreaOfLawTest {
         entity.setExternalLinkDescriptionCy("description of external link in Welsh");
         entity.setDisplayName("display name in english");
         entity.setDisplayNameCy("display name in welsh");
+        entity.setAltName("display name in english");
+        entity.setAltNameCy("display name in welsh");
         entity.setDisplayExternalLink("display external link");
     }
 
@@ -47,6 +50,32 @@ class AreaOfLawTest {
             areaOfLaw.getDisplayName()
         );
         assertEquals(entity.getDisplayExternalLink(), areaOfLaw.getDisplayExternalLink());
+
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testDisplayNameForInPersonCourt(boolean welsh) {
+        if (welsh) {
+            Locale locale = new Locale("cy");
+            LocaleContextHolder.setLocale(locale);
+        }
+        final AreaOfLaw areaOfLaw = new AreaOfLaw(entity, true);
+        assertThat(areaOfLaw.getDisplayName()).isEqualTo(welsh ? entity.getAltNameCy() : entity.getAltName());
+
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testDisplayForNotInPersonCourt(boolean welsh) {
+        if (welsh) {
+            Locale locale = new Locale("cy");
+            LocaleContextHolder.setLocale(locale);
+        }
+        final AreaOfLaw areaOfLaw = new AreaOfLaw(entity, true);
+        assertThat(areaOfLaw.getDisplayName()).isEqualTo(welsh ? entity.getDisplayNameCy() : entity.getDisplayName());
 
         LocaleContextHolder.resetLocaleContext();
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/model/CourtTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/model/CourtTest.java
@@ -81,11 +81,7 @@ class CourtTest {
         when(courtContactEntity.getContact()).thenReturn(contactEntity);
         courtEntity.setCourtContacts(singletonList(courtContactEntity));
 
-        final AreaOfLaw areaOfLawEntity = new AreaOfLaw();
-        areaOfLawEntity.setName("Divorce");
-        areaOfLawEntity.setExternalLinkDescription("Description of url");
-        areaOfLawEntity.setExternalLink("http%3A//url");
-        courtEntity.setAreasOfLaw(singletonList(areaOfLawEntity));
+        courtEntity.setAreasOfLaw(singletonList(getAreaOfLaw()));
 
         final CourtType courtTypeEntity = new CourtType();
         courtTypeEntity.setName("court type");
@@ -110,6 +106,18 @@ class CourtTest {
         courtEntity.setDirectionsCy("Directions in Welsh");
         courtEntity.setAlert("Alert");
         courtEntity.setAlertCy("Alert in Welsh");
+    }
+
+    private static AreaOfLaw getAreaOfLaw() {
+        final AreaOfLaw areaOfLawEntity = new AreaOfLaw();
+        areaOfLawEntity.setName("Divorce");
+        areaOfLawEntity.setExternalLinkDescription("Description of url");
+        areaOfLawEntity.setExternalLink("http%3A//url");
+        areaOfLawEntity.setDisplayName("Name for not in-person court");
+        areaOfLawEntity.setDisplayNameCy("Name for not in-person court cy");
+        areaOfLawEntity.setAltName("Name for in-person court");
+        areaOfLawEntity.setAltNameCy("Name for in-person court cy");
+        return areaOfLawEntity;
     }
 
     @ParameterizedTest
@@ -156,7 +164,10 @@ class CourtTest {
 
     @Test
     void testNotInPersonData() {
-        courtEntity.setInPerson(null);
+        final InPerson inPersonEntity = new InPerson();
+        inPersonEntity.setIsInPerson(false);
+        courtEntity.setInPerson(inPersonEntity);
+
         final CourtAddress courtAddress = new CourtAddress();
         courtAddress.setAddress("line 1\rline 2\nline3\r\nline4");
         final AddressType addressType = new AddressType();
@@ -165,14 +176,20 @@ class CourtTest {
         courtAddress.setPostcode("A post code");
         courtAddress.setTownName("A town name");
         courtEntity.setAddresses(singletonList(courtAddress));
-        Court court = new Court(courtEntity);
-        assertTrue(court.getInPerson());
+
+        final Court court = new Court(courtEntity);
+        assertFalse(court.getInPerson());
         assertNull(court.getAccessScheme());
         assertEquals("Write to us", court.getAddresses().get(0).getAddressType());
+        assertEquals(courtEntity.getAreasOfLaw().get(0).getDisplayName(), court.getAreasOfLaw().get(0).getDisplayName());
     }
 
     @Test
     void testInPersonData() {
+        final InPerson inPersonEntity = new InPerson();
+        inPersonEntity.setIsInPerson(true);
+        courtEntity.setInPerson(inPersonEntity);
+
         final CourtAddress courtAddress = new CourtAddress();
         courtAddress.setAddress("line 1\rline 2\nline3\r\nline4");
         final AddressType addressType = new AddressType();
@@ -181,8 +198,11 @@ class CourtTest {
         courtAddress.setPostcode("A post code");
         courtAddress.setTownName("A town name");
         courtEntity.setAddresses(singletonList(courtAddress));
-        Court court = new Court(courtEntity);
+
+        final Court court = new Court(courtEntity);
+        assertTrue(court.getInPerson());
         assertEquals("Visit us", court.getAddresses().get(0).getAddressType());
+        assertEquals(courtEntity.getAreasOfLaw().get(0).getAltName(), court.getAreasOfLaw().get(0).getDisplayName());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-881

### Change description ###

- Move Financial Remedy and Business and Property into area of law table
- Make use of the alt-name and alt_name fields on the area of law table for in-person court display name

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
