### PR TITLE
FACT-885 - Sort facilities based on the sort order of the type before returning through the admin endpoints

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/model/admin/Facility.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/admin/Facility.java
@@ -16,6 +16,5 @@ public class Facility {
         this.name = facility.getName();
         this.description = facility.getDescription();
         this.descriptionCy = facility.getDescriptionCy();
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/model/admin/FacilityType.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/model/admin/FacilityType.java
@@ -24,5 +24,4 @@ public class FacilityType {
         this.imageFilePath = facilityType.getImageFilePath();
         this.order = facilityType.getOrder();
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtFacilityService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtFacilityService.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.dts.fact.repositories.FacilityTypeRepository;
 
 import java.util.List;
 
+import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
 
 @Service
@@ -33,6 +34,7 @@ public class AdminCourtFacilityService {
         return  courtRepository.findBySlug(slug)
             .map(c -> c.getFacilities()
                 .stream()
+                .sorted(comparingInt(f -> f.getFacilityType().getOrder()))
                 .map(Facility::new)
                 .collect(toList()))
             .orElseThrow(() -> new NotFoundException(slug));
@@ -44,7 +46,7 @@ public class AdminCourtFacilityService {
         final Court courtEntity = courtRepository.findBySlug(slug)
             .orElseThrow(() -> new NotFoundException(slug));
 
-        return saveCourtFacilities(courtEntity,courtFacilities);
+        return saveCourtFacilities(courtEntity, courtFacilities);
     }
 
     protected List<Facility> saveCourtFacilities(final Court courtEntity, final List<Facility> courtFacilities) {
@@ -56,15 +58,15 @@ public class AdminCourtFacilityService {
         final List<CourtFacility> existingList = getExistingCourtFacilities(courtEntity);
 
         //remove existing court facilities and add updated facilities
-
         courtFacilityRepository.deleteAll(existingList);
 
         return courtFacilityRepository
             .saveAll(courtFacilitiesEntities)
             .stream()
-            .map(cf -> new Facility(cf.getFacility()))
+            .map(CourtFacility::getFacility)
+            .sorted(comparingInt(f -> f.getFacilityType().getOrder()))
+            .map(Facility::new)
             .collect(toList());
-
     }
 
     private List<uk.gov.hmcts.dts.fact.entity.Facility> getNewFacilityEntity(final List<Facility> facilities) {

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtFacilityServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminCourtFacilityServiceTest.java
@@ -35,6 +35,7 @@ public class AdminCourtFacilityServiceTest {
     private static final List<Facility> FACILITIES = new ArrayList<>();
     private static final List<CourtFacility> COURT_FACILITIES = new ArrayList<>();
     private static final String NOT_FOUND = "Not found: ";
+
     private static final String FACILITY_1 = "Facility1";
     private static final String FACILITY_2 = "Facility2";
     private static final String FACILITY_3 = "Facility3";
@@ -44,11 +45,19 @@ public class AdminCourtFacilityServiceTest {
     private static final String DESCRIPTION_CY_2 = "DescriptionCy2";
     private static final String DESCRIPTION_3 = "Description3";
     private static final String DESCRIPTION_CY_3 = "DescriptionCy3";
-    final List<uk.gov.hmcts.dts.fact.model.admin.Facility> expectedCourtFacilities = Arrays.asList(
+
+    private static final List<uk.gov.hmcts.dts.fact.model.admin.Facility> INPUT_COURT_FACILITIES = Arrays.asList(
         new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_1,DESCRIPTION_1,DESCRIPTION_CY_1),
         new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_2,DESCRIPTION_2,DESCRIPTION_CY_2),
-        new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_3,DESCRIPTION_3,DESCRIPTION_CY_3));
+        new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_3,DESCRIPTION_3,DESCRIPTION_CY_3)
+    );
 
+    // The expected facility results are sorted based on the sort order of the facility types and not necessary the same as the input order
+    private static final List<uk.gov.hmcts.dts.fact.model.admin.Facility> EXPECTED_COURT_FACILITIES = Arrays.asList(
+        new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_2,DESCRIPTION_2,DESCRIPTION_CY_2),
+        new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_3,DESCRIPTION_3,DESCRIPTION_CY_3),
+        new uk.gov.hmcts.dts.fact.model.admin.Facility(FACILITY_1,DESCRIPTION_1,DESCRIPTION_CY_1)
+    );
 
     @Autowired
     private AdminCourtFacilityService adminCourtFacilityService;
@@ -74,36 +83,27 @@ public class AdminCourtFacilityServiceTest {
         final FacilityType facilityType1 = new FacilityType();
         facilityType1.setId(1);
         facilityType1.setName("FacilityType1");
-        facilityType1.setImage("Image");
-        facilityType1.setImageDescription("ImageDescription");
-        facilityType1.setImageFilePath("ImagePath");
-        facilityType1.setOrder(1);
+        facilityType1.setOrder(3);
         final FacilityType facilityType2 = new FacilityType();
         facilityType2.setId(2);
         facilityType2.setName("FacilityType2");
-        facilityType1.setImage("Image");
-        facilityType1.setImageDescription("ImageDescription");
-        facilityType1.setImageFilePath("ImagePath");
-        facilityType2.setOrder(2);
+        facilityType2.setOrder(1);
         final FacilityType facilityType3 = new FacilityType();
         facilityType3.setId(3);
         facilityType3.setName("FacilityType3");
-        facilityType1.setImage("Image");
-        facilityType1.setImageDescription("ImageDescription");
-        facilityType1.setImageFilePath("ImagePath");
-        facilityType3.setOrder(3);
+        facilityType3.setOrder(2);
 
-        final Facility facility1 = new Facility("Facility1","Description1","DescriptionCy1",facilityType1);
-        final Facility facility2 = new Facility("Facility2","Description2","DescriptionCy2",facilityType2);
-        final Facility facility3 = new Facility("Facility3","Description3","DescriptionCy3",facilityType1);
+        final Facility facility1 = new Facility("Facility1", "Description1", "DescriptionCy1", facilityType1);
+        final Facility facility2 = new Facility("Facility2", "Description2", "DescriptionCy2", facilityType2);
+        final Facility facility3 = new Facility("Facility3", "Description3", "DescriptionCy3", facilityType3);
 
         FACILITIES.add(facility1);
         FACILITIES.add(facility2);
         FACILITIES.add(facility3);
 
-        final CourtFacility courtFacility1 = new CourtFacility(new Court(),facility1);
-        final CourtFacility courtFacility2 = new CourtFacility(new Court(),facility2);
-        final CourtFacility courtFacility3 = new CourtFacility(new Court(),facility3);
+        final CourtFacility courtFacility1 = new CourtFacility(new Court(), facility1);
+        final CourtFacility courtFacility2 = new CourtFacility(new Court(), facility2);
+        final CourtFacility courtFacility3 = new CourtFacility(new Court(), facility3);
 
         COURT_FACILITIES.add(courtFacility1);
         COURT_FACILITIES.add(courtFacility2);
@@ -121,10 +121,9 @@ public class AdminCourtFacilityServiceTest {
         when(court.getFacilities()).thenReturn(FACILITIES);
         when(courtRepository.findBySlug(COURT_SLUG)).thenReturn(Optional.of(court));
 
-        assertThat(adminCourtFacilityService.getCourtFacilitiesBySlug(COURT_SLUG))
-            .hasSize(FACILITY_COUNT)
-            .first()
-            .isInstanceOf(uk.gov.hmcts.dts.fact.model.admin.Facility.class);
+        final List<uk.gov.hmcts.dts.fact.model.admin.Facility> results = adminCourtFacilityService.getCourtFacilitiesBySlug(COURT_SLUG);
+        assertThat(results).hasSize(FACILITY_COUNT);
+        assertThat(results).containsExactlyElementsOf(EXPECTED_COURT_FACILITIES);
     }
 
     @Test
@@ -143,22 +142,19 @@ public class AdminCourtFacilityServiceTest {
         when(courtRepository.save(court)).thenReturn(court);
         when(facilityTypeRepository.findByName(any())).thenReturn(Optional.of(facilityType));
 
-        assertThat(adminCourtFacilityService.updateCourtFacility(COURT_SLUG,expectedCourtFacilities))
+        assertThat(adminCourtFacilityService.updateCourtFacility(COURT_SLUG, INPUT_COURT_FACILITIES))
             .hasSize(FACILITY_COUNT)
-            .containsExactlyElementsOf(expectedCourtFacilities);
+            .containsExactlyElementsOf(EXPECTED_COURT_FACILITIES);
     }
-
 
     @Test
     void shouldReturnNotFoundWhenUpdatingCourtFacilityForNonExistentCourt() {
 
         when(courtRepository.findBySlug(COURT_SLUG)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> adminCourtFacilityService.updateCourtFacility(COURT_SLUG,expectedCourtFacilities))
+        assertThatThrownBy(() -> adminCourtFacilityService.updateCourtFacility(COURT_SLUG, INPUT_COURT_FACILITIES))
             .isInstanceOf(NotFoundException.class)
             .hasMessage(NOT_FOUND + COURT_SLUG);
     }
-
-
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-885

### Change description ###

Sort facilities based on the sort order of the type before returning through the admin endpoints

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
