### PR TITLE
FACT Postcodes API functional test small change

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
@@ -286,7 +286,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
 
         final String updatedJson = objectMapper().writeValueAsString(POSTCODES_DO_NOT_EXIST);
 
-        final var response = doPostRequest(
+        final var response = doDeleteRequest(
             COURT_NOT_FIND_PATH,
             Map.of(AUTHORIZATION, BEARER + superAdminToken),
             updatedJson


### PR DESCRIPTION
There was a test where PostRequest used instead of DeleteRequest. Changed it



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
