### PR TITLE
Update chart to new release

### DIFF
--- a/charts/fact-api/Chart.yaml
+++ b/charts/fact-api/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for FACT API
 name: fact-api
 home: https://github.com/hmcts/fact-api
-version: 0.0.23
+version: 0.0.24
 maintainers:
   - name: HMCTS fact team
 dependencies:
   - name: java
-    version: 3.7.0
+    version: 3.7.1
     repository: '@hmctspublic'


### PR DESCRIPTION
After work on DTSPO-6881, pods failed to restart in 01 cluster for taking too long. New java-chart release has been published to accommodate for this - https://github.com/hmcts/chart-java/releases/tag/3.7.1. @damongreen123




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
