### PR TITLE
Fact 1015

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,13 @@ dependencyManagement {
     dependencySet(group: 'commons-io', version: '2.11.0') {
       entry 'commons-io'
     }
+    // solves CVE-2022-25857
+    dependencySet(
+      group: 'org.yaml',
+      version: '1.31'
+    ) {
+      entry 'snakeyaml'
+    }
   }
   imports {
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:2020.0.4"
@@ -230,7 +237,7 @@ dependencies {
   implementation group: 'org.flywaydb', name: 'flyway-core'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.9.2'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.1'
 
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.18.0'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.18.0'

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtFacilityEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtFacilityEndpointTest.java
@@ -5,6 +5,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.dts.fact.html.sanitizer.OwaspHtmlSanitizer;
 import uk.gov.hmcts.dts.fact.model.admin.Facility;
 import uk.gov.hmcts.dts.fact.model.admin.FacilityType;
 import uk.gov.hmcts.dts.fact.util.AdminFunctionalTestBase;
@@ -145,6 +146,10 @@ public class AdminCourtFacilityEndpointTest extends AdminFunctionalTestBase {
 
     @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
     private List<Facility> updateFacilities(final List<Facility> facilities) {
+        for (Facility facility: facilities) {
+            facility.setDescription(OwaspHtmlSanitizer.sanitizeHtml(facility.getDescription()));
+            facility.setDescriptionCy(OwaspHtmlSanitizer.sanitizeHtml(facility.getDescriptionCy()));
+        }
         final List<Facility> updatedFacilities = new ArrayList<>(facilities);
         Facility facility = new Facility();
         facility.setId(TEST_FACILITY_ID_1);

--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/EmailType.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/EmailType.java
@@ -23,6 +23,7 @@ public class EmailType extends ElementType {
     private String descriptionCy;
 
     public EmailType(String description, String descriptionCy) {
+        super();
         this.description = description;
         this.descriptionCy = descriptionCy;
     }

--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/EmailType.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/EmailType.java
@@ -5,10 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Table(name = "admin_emailtype")
@@ -18,8 +15,15 @@ import javax.persistence.Table;
 @NoArgsConstructor
 public class EmailType extends ElementType {
     @Id
+    @SequenceGenerator(name = "seq-gen", sequenceName = "search_email_type_id_seq", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "seq-gen")
     private Integer id;
     private String description;
     @Column(name = "description_cy")
     private String descriptionCy;
+
+    public EmailType(String description, String descriptionCy) {
+        this.description = description;
+        this.descriptionCy = descriptionCy;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/repositories/EmailTypeRepository.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/repositories/EmailTypeRepository.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dts.fact.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.hmcts.dts.fact.entity.EmailType;
-import uk.gov.hmcts.dts.fact.entity.FacilityType;
 
 import java.util.Optional;
 

--- a/src/main/java/uk/gov/hmcts/dts/fact/repositories/EmailTypeRepository.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/repositories/EmailTypeRepository.java
@@ -2,6 +2,10 @@ package uk.gov.hmcts.dts.fact.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.hmcts.dts.fact.entity.EmailType;
+import uk.gov.hmcts.dts.fact.entity.FacilityType;
+
+import java.util.Optional;
 
 public interface EmailTypeRepository extends JpaRepository<EmailType, Integer> {
+    Optional<EmailType> findByDescription(String description);
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/list/AdminContactTypeService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/list/AdminContactTypeService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.dts.fact.exception.NotFoundException;
 import uk.gov.hmcts.dts.fact.model.admin.ContactType;
 import uk.gov.hmcts.dts.fact.repositories.ContactRepository;
 import uk.gov.hmcts.dts.fact.repositories.ContactTypeRepository;
+import uk.gov.hmcts.dts.fact.repositories.EmailTypeRepository;
 
 import java.util.Comparator;
 import java.util.List;
@@ -24,12 +25,15 @@ public class AdminContactTypeService {
 
     private final ContactTypeRepository contactTypeRepository;
     private final ContactRepository contactRepository;
+    private final EmailTypeRepository emailTypeRepository;
 
     @Autowired
-    public AdminContactTypeService(final ContactTypeRepository contactTypeRepository, final ContactRepository contactRepository) {
+    public AdminContactTypeService(final ContactTypeRepository contactTypeRepository,
+                                   final ContactRepository contactRepository,
+                                   final EmailTypeRepository emailTypeRepository) {
         this.contactTypeRepository = contactTypeRepository;
         this.contactRepository = contactRepository;
-
+        this.emailTypeRepository = emailTypeRepository;
     }
 
     public List<ContactType> getAllContactTypes() {
@@ -51,6 +55,7 @@ public class AdminContactTypeService {
     @Transactional
     public ContactType createContactType(final ContactType contactType) {
         checkIfContactTypeAlreadyExists(contactType.getType());
+        emailTypeRepository.save(new uk.gov.hmcts.dts.fact.entity.EmailType(contactType.getType(), contactType.getTypeCy()));
         return new ContactType(contactTypeRepository.save(createNewContactTypeEntityFromModel(contactType)));
     }
 
@@ -59,17 +64,36 @@ public class AdminContactTypeService {
         uk.gov.hmcts.dts.fact.entity.ContactType contactTypeEntity =
             contactTypeRepository.findById(updatedContactType.getId())
                 .orElseThrow(() -> new NotFoundException(updatedContactType.getId().toString()));
-
         checkIfUpdatedContactTypeAlreadyExists(updatedContactType);
+
+        // Also get the email list type and update it too
+        // Note: we are doing this as opposed to merging the two lists together to avoid having to
+        // update each courts addresses in the live environment
+        uk.gov.hmcts.dts.fact.entity.EmailType emailTypeEntity =
+            emailTypeRepository.findByDescription(contactTypeEntity.getDescription())
+                .orElseThrow(() -> new NotFoundException(updatedContactType.getType()));
+
+        emailTypeEntity.setDescription(updatedContactType.getType());
+        emailTypeEntity.setDescriptionCy(updatedContactType.getTypeCy());
         contactTypeEntity.setDescription(updatedContactType.getType());
         contactTypeEntity.setDescriptionCy(updatedContactType.getTypeCy());
+        emailTypeRepository.save(emailTypeEntity);
         return new ContactType(contactTypeRepository.save(contactTypeEntity));
     }
 
     public void deleteContactType(final Integer contactTypeId) {
+
+        uk.gov.hmcts.dts.fact.entity.ContactType contactTypeEntity =
+            contactTypeRepository.findById(contactTypeId)
+                .orElseThrow(() -> new NotFoundException(contactTypeId.toString()));
         checkContactTypeIsNotInUse(contactTypeId);
 
+        uk.gov.hmcts.dts.fact.entity.EmailType emailTypeEntity =
+            emailTypeRepository.findByDescription(contactTypeEntity.getDescription())
+                .orElseThrow(() -> new NotFoundException(contactTypeEntity.getDescription()));
+
         try {
+            emailTypeRepository.deleteById(emailTypeEntity.getId());
             contactTypeRepository.deleteById(contactTypeId);
         } catch (EmptyResultDataAccessException ex) {
             log.warn("Contact Type could not be deleted because it no longer exists: " + contactTypeId);

--- a/src/main/resources/db/migration/V171__synchronise_contact_email_types.sql
+++ b/src/main/resources/db/migration/V171__synchronise_contact_email_types.sql
@@ -1,0 +1,18 @@
+INSERT INTO public.admin_contacttype (name, name_cy)
+SELECT et.description, et.description_cy FROM public.admin_contacttype ct -- ones in contact
+RIGHT JOIN public.admin_emailtype et -- ones in email
+ON et.description = ct.name
+WHERE et.description NOT IN (
+    SELECT ct.name
+    FROM public.admin_contacttype ct
+);
+
+INSERT INTO public.admin_emailtype (description, description_cy)
+SELECT ct.name, ct.name_cy
+FROM public.admin_emailtype et -- ones in contact
+         RIGHT JOIN public.admin_contacttype ct -- ones in email
+                    on et.description = ct.name
+WHERE ct.name NOT IN (
+    SELECT et.description
+    FROM public.admin_emailtype et
+);

--- a/src/main/resources/db/migration/V171__synchronise_contact_email_types.sql
+++ b/src/main/resources/db/migration/V171__synchronise_contact_email_types.sql
@@ -16,3 +16,16 @@ WHERE ct.name NOT IN (
     SELECT et.description
     FROM public.admin_emailtype et
 );
+
+
+CREATE SEQUENCE public.search_email_type_id_seq
+	START WITH 100
+	INCREMENT BY 1
+	NO MINVALUE
+	NO MAXVALUE
+	CACHE 1;
+
+ALTER SEQUENCE public.search_email_type_id_seq OWNED BY public.admin_emailtype.id;
+
+ALTER TABLE ONLY public.admin_emailtype
+	ALTER COLUMN id SET DEFAULT nextval('public.search_email_type_id_seq'::regclass);

--- a/src/main/resources/db/migration/V171__synchronise_contact_email_types.sql
+++ b/src/main/resources/db/migration/V171__synchronise_contact_email_types.sql
@@ -1,6 +1,6 @@
 INSERT INTO public.admin_contacttype (name, name_cy)
 SELECT et.description, et.description_cy FROM public.admin_contacttype ct -- ones in contact
-RIGHT JOIN public.admin_emailtype et -- ones in email
+RIGHT JOIN public.admin_emailtype et
 ON et.description = ct.name
 WHERE et.description NOT IN (
     SELECT ct.name
@@ -9,8 +9,8 @@ WHERE et.description NOT IN (
 
 INSERT INTO public.admin_emailtype (description, description_cy)
 SELECT ct.name, ct.name_cy
-FROM public.admin_emailtype et -- ones in contact
-         RIGHT JOIN public.admin_contacttype ct -- ones in email
+FROM public.admin_emailtype et
+         RIGHT JOIN public.admin_contacttype ct
                     on et.description = ct.name
 WHERE ct.name NOT IN (
     SELECT et.description


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1015


### Change description ###
To synchronise the contact and email type lists 
When performing CRUD operations on contact list, reflect the changes on the email types table 

This is done instead of combining the two to ensure we do not compromise the data for the production region for active court addresses

