### PR TITLE
FACT-1178 changed exceptions to return json instead of string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ dependencyManagement {
     // solves CVE-2022-25857
     dependencySet(
       group: 'org.yaml',
-      version: '1.31'
+      version: '1.33'
     ) {
       entry 'snakeyaml'
     }
@@ -240,7 +240,7 @@ dependencies {
   implementation group: 'org.flywaydb', name: 'flyway-core'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.1'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.2'
 
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.18.0'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.18.0'
@@ -248,8 +248,8 @@ dependencies {
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.65'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.23'
 
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.3'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0-rc1'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0-rc1'
   implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: '2.13.3', ext: 'pom'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.13.3'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,6 +9,7 @@
     <cve>CVE-2021-22112</cve>
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2020-5408</cve> <!-- Wait until a version exists that fixes this -->
+    <cve>CVE-2022-38752</cve> <!-- Wait until a version exists that fixes this -->
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-34305</cve> <!-- 8/7/22: Upgrade to Apache Tomcat 9.0.65 or later once released  -->

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,6 +10,7 @@
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2020-5408</cve> <!-- Wait until a version exists that fixes this -->
     <cve>CVE-2022-38752</cve> <!-- Wait until a version exists that fixes this -->
+    <cve>CVE-2021-43980</cve>
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-34305</cve> <!-- 8/7/22: Upgrade to Apache Tomcat 9.0.65 or later once released  -->

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
@@ -59,6 +59,8 @@ public class AdminCourtAddressEndpointTest extends AdminFunctionalTestBase {
 
     private static final String POSTCODE_VALID = "PL6 5DQ";
     private static final String POSTCODES_INVALID = "PL2 56ERR";
+    private static final String INVALID_POSTCODES_MESSAGE = "[%s]";
+    private static final String POSTCODES_INVALID_RESPONSE_ERROR = String.format(INVALID_POSTCODES_MESSAGE, POSTCODES_INVALID);
 
     /************************************************************* Get Request Tests. ***************************************************************/
 
@@ -160,9 +162,9 @@ public class AdminCourtAddressEndpointTest extends AdminFunctionalTestBase {
             Map.of(AUTHORIZATION, BEARER + superAdminToken),
             updatedJson
         );
-        final List<String> invalidPostcodes = new ArrayList<>(Arrays.asList(response.body().jsonPath().getString("message").split(",")));
+        final String invalidPostcodes = response.body().jsonPath().getString("message");
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        assertThat(invalidPostcodes).containsExactly(POSTCODES_INVALID);
+        assertThat(invalidPostcodes).isEqualTo(POSTCODES_INVALID_RESPONSE_ERROR);
 
         // Test that the addresses are not updated, i.e. the original addresses remain
         final List<CourtAddress> updatedCourtAddresses = getCurrentCourtAddress();

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
@@ -161,7 +161,7 @@ public class AdminCourtAddressEndpointTest extends AdminFunctionalTestBase {
             Map.of(AUTHORIZATION, BEARER + superAdminToken),
             updatedJson
         );
-        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
+        final List<String> invalidPostcodes = new ArrayList<>(Arrays.asList(response.body().jsonPath().getString("message").split(",")));
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
         assertThat(invalidPostcodes).containsExactly(POSTCODES_INVALID);
 

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
@@ -160,7 +160,7 @@ public class AdminCourtAddressEndpointTest extends AdminFunctionalTestBase {
             Map.of(AUTHORIZATION, BEARER + superAdminToken),
             updatedJson
         );
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".", String.class);
+        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
         assertThat(invalidPostcodes).containsExactly(POSTCODES_INVALID);
 

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.dts.fact.util.AdminFunctionalTestBase;
 
 import java.util.*;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtAddressEndpointTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.dts.fact.util.AdminFunctionalTestBase;
 
 import java.util.*;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
@@ -160,7 +161,7 @@ public class AdminCourtAddressEndpointTest extends AdminFunctionalTestBase {
             Map.of(AUTHORIZATION, BEARER + superAdminToken),
             updatedJson
         );
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
+        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
         assertThat(invalidPostcodes).containsExactly(POSTCODES_INVALID);
 

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
@@ -208,7 +208,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
+        final List<String> invalidPostcodes = new ArrayList<>(Arrays.asList(response.body().jsonPath().getString("message").split(",")));
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }
 
@@ -265,7 +265,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
+        final List<String> invalidPostcodes = new ArrayList<>(Arrays.asList(response.body().jsonPath().getString("message").split(",")));
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
@@ -208,7 +208,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
+        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }
 
@@ -265,7 +265,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
+        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }
 
@@ -428,7 +428,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             invalidPostcodesToMoveJson
         );
 
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
+        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
@@ -208,7 +208,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".", String.class);
+        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }
 
@@ -265,7 +265,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".", String.class);
+        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }
 
@@ -428,7 +428,7 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             invalidPostcodesToMoveJson
         );
 
-        final List<String> invalidPostcodes = response.body().jsonPath().getList(".", String.class);
+        final List<String> invalidPostcodes = response.body().jsonPath().getList(".message", String.class);
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
         assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/admin/AdminCourtPostcodeEndpointTest.java
@@ -208,8 +208,8 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = new ArrayList<>(Arrays.asList(response.body().jsonPath().getString("message").split(",")));
-        assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
+        final String invalidPostcodes = response.body().jsonPath().getString("message");
+        assertThat(invalidPostcodes).isEqualTo(POSTCODES_INVALID_RESPONSE.toString());
     }
 
     @Test
@@ -265,8 +265,8 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             updatedJson
         );
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        final List<String> invalidPostcodes = new ArrayList<>(Arrays.asList(response.body().jsonPath().getString("message").split(",")));
-        assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
+        final String invalidPostcodes = response.body().jsonPath().getString("message");
+        assertThat(invalidPostcodes).isEqualTo(POSTCODES_INVALID_RESPONSE.toString());
     }
 
     @Test
@@ -427,10 +427,9 @@ public class AdminCourtPostcodeEndpointTest extends AdminFunctionalTestBase {
             Map.of(AUTHORIZATION, BEARER + superAdminToken),
             invalidPostcodesToMoveJson
         );
-
-        final List<String> invalidPostcodes = singletonList(response.body().jsonPath().getString(".message"));
+        final String invalidPostcodes = response.body().jsonPath().getString("message");
         assertThat(response.statusCode()).isEqualTo(BAD_REQUEST.value());
-        assertThat(invalidPostcodes).containsExactlyInAnyOrderElementsOf(POSTCODES_INVALID_RESPONSE);
+        assertThat(invalidPostcodes).isEqualTo(POSTCODES_INVALID_RESPONSE.toString());
     }
 
     /************************************************************* Shared utility methods. ***************************************************************/

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -25,12 +25,17 @@ public class GlobalControllerExceptionHandler {
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(InvalidPostcodeException.class)
-    ResponseEntity invalidPostcodeExceptionHandler(final InvalidPostcodeException ex) {
+    @ExceptionHandler(value = {InvalidPostcodeException.class})
+    ResponseEntity invalidPostcodeExceptionHandler(final InvalidPostcodeException ex) throws JsonProcessingException {
+        HashMap<String, String> error = new HashMap<>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Content-Type", "application/json");
         if (ex.getInvalidPostcodes().isEmpty()) {
-            return badRequest().body(ex.getMessage());
+            error.put("message", ex.getMessage());
+        } else {
+            error.put("message", ex.getInvalidPostcodes().toString());
         }
-        return badRequest().body(ex.getInvalidPostcodes());
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(value = {IllegalArgumentException.class})

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -71,8 +71,12 @@ public class GlobalControllerExceptionHandler {
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(ListItemInUseException.class)
-    ResponseEntity<String> listItemInUseExceptionHandler(final ListItemInUseException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+    @ExceptionHandler(value = {ListItemInUseException.class})
+    ResponseEntity<String> listItemInUseExceptionHandler(final ListItemInUseException ex) throws JsonProcessingException {
+        HashMap<String, String> error = new HashMap<>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Content-Type", "application/json");
+        error.put("message", ex.getMessage());
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -14,6 +14,7 @@ import java.util.List;
 @ControllerAdvice
 public class GlobalControllerExceptionHandler {
 
+    private static final String MESSAGE = "message";
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String APPLICATION_JSON = "application/json";
 
@@ -22,7 +23,7 @@ public class GlobalControllerExceptionHandler {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
-        error.put("message", ex.getMessage());
+        error.put(MESSAGE, ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.NOT_FOUND);
     }
 
@@ -32,9 +33,9 @@ public class GlobalControllerExceptionHandler {
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         if (ex.getInvalidPostcodes().isEmpty()) {
-            error.put("message", ex.getMessage());
+            error.put(MESSAGE, ex.getMessage());
         } else {
-            error.put("message", ex.getInvalidPostcodes().toString());
+            error.put(MESSAGE, ex.getInvalidPostcodes().toString());
         }
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
@@ -44,7 +45,7 @@ public class GlobalControllerExceptionHandler {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
-        error.put("message", ex.getMessage());
+        error.put(MESSAGE, ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
@@ -63,7 +64,7 @@ public class GlobalControllerExceptionHandler {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
-        error.put("message", ex.getMessage());
+        error.put(MESSAGE, ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.CONFLICT);
     }
 
@@ -72,7 +73,7 @@ public class GlobalControllerExceptionHandler {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
-        error.put("message", ex.getMessage());
+        error.put(MESSAGE, ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
@@ -80,8 +81,8 @@ public class GlobalControllerExceptionHandler {
     ResponseEntity<String> listItemInUseExceptionHandler(final ListItemInUseException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set("Content-Type", "application/json");
-        error.put("message", ex.getMessage());
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
+        error.put(MESSAGE, ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -62,9 +62,13 @@ public class GlobalControllerExceptionHandler {
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler(IllegalListItemException.class)
-    ResponseEntity<String> illegalListItemExceptionHandler(final IllegalListItemException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(value = {IllegalListItemException.class})
+    ResponseEntity<String> illegalListItemExceptionHandler(final IllegalListItemException ex) throws JsonProcessingException {
+        HashMap<String, String> error = new HashMap<>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Content-Type", "application/json");
+        error.put("message", ex.getMessage());
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ListItemInUseException.class)

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -17,8 +17,7 @@ import static org.springframework.http.ResponseEntity.badRequest;
 public class GlobalControllerExceptionHandler {
 
     @ExceptionHandler(value = {NotFoundException.class})
-    ResponseEntity<String> notFoundExceptionHandler(final NotFoundException ex) throws JsonProcessingException
-    {
+    ResponseEntity<String> notFoundExceptionHandler(final NotFoundException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set("Content-Type", "application/json");

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -1,19 +1,29 @@
 package uk.gov.hmcts.dts.fact.exception;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static org.springframework.http.ResponseEntity.badRequest;
 
 @ControllerAdvice
 public class GlobalControllerExceptionHandler {
-    @ExceptionHandler(NotFoundException.class)
-    ResponseEntity<String> notFoundExceptionHandler(final NotFoundException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+
+    @ExceptionHandler(value = {NotFoundException.class})
+    ResponseEntity<String> notFoundExceptionHandler(final NotFoundException ex) throws JsonProcessingException
+    {
+        HashMap<String, String> error = new HashMap<>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Content-Type", "application/json");
+        error.put("message", ex.getMessage());
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(InvalidPostcodeException.class)

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -14,20 +14,23 @@ import java.util.List;
 @ControllerAdvice
 public class GlobalControllerExceptionHandler {
 
-    @ExceptionHandler(value = {NotFoundException.class})
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String APPLICATION_JSON = "application/json";
+
+    @ExceptionHandler(NotFoundException.class)
     ResponseEntity<String> notFoundExceptionHandler(final NotFoundException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set("Content-Type", "application/json");
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         error.put("message", ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(value = {InvalidPostcodeException.class})
+    @ExceptionHandler(InvalidPostcodeException.class)
     ResponseEntity invalidPostcodeExceptionHandler(final InvalidPostcodeException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set("Content-Type", "application/json");
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         if (ex.getInvalidPostcodes().isEmpty()) {
             error.put("message", ex.getMessage());
         } else {
@@ -36,11 +39,11 @@ public class GlobalControllerExceptionHandler {
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(value = {IllegalArgumentException.class})
+    @ExceptionHandler(IllegalArgumentException.class)
     ResponseEntity<String> illegalArgumentExceptionHandler(final IllegalArgumentException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set("Content-Type", "application/json");
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         error.put("message", ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
@@ -55,25 +58,25 @@ public class GlobalControllerExceptionHandler {
         return new ResponseEntity<>(ex.getInvalidPostcodes(), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(value = {DuplicatedListItemException.class})
+    @ExceptionHandler(DuplicatedListItemException.class)
     ResponseEntity<String> duplicateListItemExceptionHandler(final DuplicatedListItemException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set("Content-Type", "application/json");
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         error.put("message", ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler(value = {IllegalListItemException.class})
+    @ExceptionHandler(IllegalListItemException.class)
     ResponseEntity<String> illegalListItemExceptionHandler(final IllegalListItemException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set("Content-Type", "application/json");
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         error.put("message", ex.getMessage());
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(value = {ListItemInUseException.class})
+    @ExceptionHandler(ListItemInUseException.class)
     ResponseEntity<String> listItemInUseExceptionHandler(final ListItemInUseException ex) throws JsonProcessingException {
         HashMap<String, String> error = new HashMap<>();
         HttpHeaders responseHeaders = new HttpHeaders();

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.springframework.http.ResponseEntity.badRequest;
-
 @ControllerAdvice
 public class GlobalControllerExceptionHandler {
 

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -53,9 +53,13 @@ public class GlobalControllerExceptionHandler {
         return new ResponseEntity<>(ex.getInvalidPostcodes(), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(DuplicatedListItemException.class)
-    ResponseEntity<String> duplicateListItemExceptionHandler(final DuplicatedListItemException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+    @ExceptionHandler(value = {DuplicatedListItemException.class})
+    ResponseEntity<String> duplicateListItemExceptionHandler(final DuplicatedListItemException ex) throws JsonProcessingException {
+        HashMap<String, String> error = new HashMap<>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Content-Type", "application/json");
+        error.put("message", ex.getMessage());
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(IllegalListItemException.class)

--- a/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/exception/GlobalControllerExceptionHandler.java
@@ -34,9 +34,13 @@ public class GlobalControllerExceptionHandler {
         return badRequest().body(ex.getInvalidPostcodes());
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    ResponseEntity<String> illegalArgumentExceptionHandler(final IllegalArgumentException ex) {
-        return badRequest().body(ex.getMessage());
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    ResponseEntity<String> illegalArgumentExceptionHandler(final IllegalArgumentException ex) throws JsonProcessingException {
+        HashMap<String, String> error = new HashMap<>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Content-Type", "application/json");
+        error.put("message", ex.getMessage());
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error), responseHeaders, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(PostcodeExistedException.class)

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAdditionalLinkControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAdditionalLinkControllerTest.java
@@ -49,6 +49,8 @@ public class AdminCourtAdditionalLinkControllerTest {
     );
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static String additionalLinksJson;
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
 
     @Autowired
     private transient MockMvc mockMvc;
@@ -76,7 +78,7 @@ public class AdminCourtAdditionalLinkControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDITIONAL_LINKS_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -100,6 +102,6 @@ public class AdminCourtAdditionalLinkControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAdditionalLinkControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAdditionalLinkControllerTest.java
@@ -50,7 +50,8 @@ public class AdminCourtAdditionalLinkControllerTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static String additionalLinksJson;
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
 
     @Autowired
     private transient MockMvc mockMvc;
@@ -78,7 +79,7 @@ public class AdminCourtAdditionalLinkControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDITIONAL_LINKS_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -102,6 +103,6 @@ public class AdminCourtAdditionalLinkControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAddressControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAddressControllerTest.java
@@ -33,6 +33,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 public class AdminCourtAddressControllerTest {
     private static final String TEST_SLUG = "court-slug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String BASE_PATH = "/admin/courts/";
     private static final String ADDRESSES_PATH = "/" + "addresses";
 
@@ -97,7 +99,7 @@ public class AdminCourtAddressControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDRESSES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -125,7 +127,7 @@ public class AdminCourtAddressControllerTest {
 
         resultActions
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -133,13 +135,12 @@ public class AdminCourtAddressControllerTest {
         final List<String> expectedResult = singletonList(POSTCODE2);
         final String expectedResultJson = OBJECT_MAPPER.writeValueAsString(expectedResult);
         when(adminService.validateCourtAddressPostcodes(COURT_ADDRESSES)).thenReturn(singletonList(POSTCODE2));
-
         mockMvc.perform(put(BASE_PATH + TEST_SLUG + ADDRESSES_PATH)
                             .content(courtAddressesJson)
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json(expectedResultJson));
+            .andExpect(content().json("{\""+MESSAGE+"\":\"["+POSTCODE2+"]\"}"));
 
         verify(adminService, never()).updateCourtAddressesAndCoordinates(TEST_SLUG, COURT_ADDRESSES);
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAddressControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAddressControllerTest.java
@@ -34,10 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AdminCourtAddressControllerTest {
     private static final String TEST_SLUG = "court-slug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
     private static final String BASE_PATH = "/admin/courts/";
     private static final String ADDRESSES_PATH = "/" + "addresses";
-
     private static final List<String> ADDRESS1 = Arrays.asList("first address line 1", "first address line 2");
     private static final List<String> ADDRESS2 = Arrays.asList("second address line 1", "second address line 2");
     private static final String TOWN_NAME1 = "first town";
@@ -45,6 +43,9 @@ public class AdminCourtAddressControllerTest {
     private static final String POSTCODE1 = "first postcode";
     private static final String POSTCODE2 = "second postcode";
     private static final Integer COUNTY = 1;
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
+    private static final String JSON_POSTCODE2 = String.format(MESSAGE, singletonList(POSTCODE2));
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -99,7 +100,7 @@ public class AdminCourtAddressControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDRESSES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -127,20 +128,18 @@ public class AdminCourtAddressControllerTest {
 
         resultActions
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
     void shouldReturnBadRequestWhenUpdatingAddressesWithAnInvalidPostcode() throws Exception {
-        final List<String> expectedResult = singletonList(POSTCODE2);
-        final String expectedResultJson = OBJECT_MAPPER.writeValueAsString(expectedResult);
         when(adminService.validateCourtAddressPostcodes(COURT_ADDRESSES)).thenReturn(singletonList(POSTCODE2));
         mockMvc.perform(put(BASE_PATH + TEST_SLUG + ADDRESSES_PATH)
                             .content(courtAddressesJson)
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"[" + POSTCODE2 + "]\"}"));
+            .andExpect(content().json(JSON_POSTCODE2));
 
         verify(adminService, never()).updateCourtAddressesAndCoordinates(TEST_SLUG, COURT_ADDRESSES);
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAddressControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAddressControllerTest.java
@@ -99,7 +99,7 @@ public class AdminCourtAddressControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDRESSES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -127,7 +127,7 @@ public class AdminCourtAddressControllerTest {
 
         resultActions
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class AdminCourtAddressControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\"["+POSTCODE2+"]\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"[" + POSTCODE2 + "]\"}"));
 
         verify(adminService, never()).updateCourtAddressesAndCoordinates(TEST_SLUG, COURT_ADDRESSES);
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtApplicationUpdateControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtApplicationUpdateControllerTest.java
@@ -27,6 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 public class AdminCourtApplicationUpdateControllerTest {
     private static final String TEST_SLUG = "court-slug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String BASE_PATH = "/admin/courts/";
     private static final String ADDRESSES_PATH = "/" + "application-progression";
 
@@ -66,7 +68,7 @@ public class AdminCourtApplicationUpdateControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDRESSES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -90,6 +92,6 @@ public class AdminCourtApplicationUpdateControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtApplicationUpdateControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtApplicationUpdateControllerTest.java
@@ -28,7 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AdminCourtApplicationUpdateControllerTest {
     private static final String TEST_SLUG = "court-slug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final String BASE_PATH = "/admin/courts/";
     private static final String ADDRESSES_PATH = "/" + "application-progression";
 
@@ -68,7 +69,7 @@ public class AdminCourtApplicationUpdateControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ADDRESSES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -92,6 +93,6 @@ public class AdminCourtApplicationUpdateControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAreasOfLawControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAreasOfLawControllerTest.java
@@ -29,7 +29,8 @@ public class AdminCourtAreasOfLawControllerTest {
     private static final String CHILD_PATH = "/courtAreasOfLaw";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final String TEST_COURT_AREAS_OF_LAW_PATH = "court-areas-of-law.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -57,7 +58,7 @@ public class AdminCourtAreasOfLawControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -87,6 +88,6 @@ public class AdminCourtAreasOfLawControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAreasOfLawControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtAreasOfLawControllerTest.java
@@ -28,6 +28,8 @@ public class AdminCourtAreasOfLawControllerTest {
     private static final String BASE_PATH = "/admin/courts/";
     private static final String CHILD_PATH = "/courtAreasOfLaw";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_COURT_AREAS_OF_LAW_PATH = "court-areas-of-law.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -55,7 +57,7 @@ public class AdminCourtAreasOfLawControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -85,6 +87,6 @@ public class AdminCourtAreasOfLawControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtContactControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtContactControllerTest.java
@@ -28,6 +28,8 @@ public class AdminCourtContactControllerTest {
     private static final String BASE_PATH = "/admin/courts/";
     private static final String CONTACTS_PATH = "/" + "contacts";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_CONTACTS_FILE = "contacts.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -55,7 +57,7 @@ public class AdminCourtContactControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CONTACTS_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -85,7 +87,7 @@ public class AdminCourtContactControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtContactControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtContactControllerTest.java
@@ -29,7 +29,8 @@ public class AdminCourtContactControllerTest {
     private static final String CONTACTS_PATH = "/" + "contacts";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final String TEST_CONTACTS_FILE = "contacts.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -57,7 +58,7 @@ public class AdminCourtContactControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CONTACTS_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class AdminCourtContactControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtEmailsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtEmailsControllerTest.java
@@ -31,7 +31,8 @@ public class AdminCourtEmailsControllerTest {
     private static final String ALL_EMAIL_TYPES_PATH = "emailTypes";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final String TEST_EMAILS_FILE = "emails.json";
     private static final String TEST_EMAIL_TYPES_FILE = "email-types.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -60,7 +61,7 @@ public class AdminCourtEmailsControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ALL_EMAILS_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -90,7 +91,7 @@ public class AdminCourtEmailsControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtEmailsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtEmailsControllerTest.java
@@ -30,6 +30,8 @@ public class AdminCourtEmailsControllerTest {
     private static final String ALL_EMAILS_PATH = "/emails";
     private static final String ALL_EMAIL_TYPES_PATH = "emailTypes";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_EMAILS_FILE = "emails.json";
     private static final String TEST_EMAIL_TYPES_FILE = "email-types.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -58,7 +60,7 @@ public class AdminCourtEmailsControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + ALL_EMAILS_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -88,7 +90,7 @@ public class AdminCourtEmailsControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtFacilityControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtFacilityControllerTest.java
@@ -30,6 +30,7 @@ public class AdminCourtFacilityControllerTest {
     private static final String TEST_SLUG = "unknownSlug";
     private static final String TEST_FACILITIES_PATH = "facilities.json";
     private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_UNKNOWN_COURT_MESSAGE = "Court not found";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -57,7 +58,7 @@ public class AdminCourtFacilityControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + FACILITIES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -89,7 +90,7 @@ public class AdminCourtFacilityControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().string(TEST_UNKNOWN_COURT_MESSAGE));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+TEST_UNKNOWN_COURT_MESSAGE+"\"}"));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtFacilityControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtFacilityControllerTest.java
@@ -30,8 +30,11 @@ public class AdminCourtFacilityControllerTest {
     private static final String TEST_SLUG = "unknownSlug";
     private static final String TEST_FACILITIES_PATH = "facilities.json";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
     private static final String TEST_UNKNOWN_COURT_MESSAGE = "Court not found";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
+    private static final String JSON_NOT_FOUND_TEST_UNKNOWN_COURT_MESSAGE = String.format(MESSAGE, TEST_UNKNOWN_COURT_MESSAGE);
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -58,7 +61,7 @@ public class AdminCourtFacilityControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + FACILITIES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -90,7 +93,7 @@ public class AdminCourtFacilityControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + TEST_UNKNOWN_COURT_MESSAGE + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_UNKNOWN_COURT_MESSAGE));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtFacilityControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtFacilityControllerTest.java
@@ -58,7 +58,7 @@ public class AdminCourtFacilityControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + FACILITIES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class AdminCourtFacilityControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+TEST_UNKNOWN_COURT_MESSAGE+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + TEST_UNKNOWN_COURT_MESSAGE + "\"}"));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
@@ -27,7 +27,8 @@ public class AdminCourtGeneralInfoControllerTest {
     private static final String CHILD_PATH = "/generalInfo";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final CourtGeneralInfo COURT_GENERAL_INFO = new CourtGeneralInfo(
         "Test court name",
         true,
@@ -71,7 +72,7 @@ public class AdminCourtGeneralInfoControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -95,6 +96,6 @@ public class AdminCourtGeneralInfoControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
@@ -71,7 +71,7 @@ public class AdminCourtGeneralInfoControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -95,6 +95,6 @@ public class AdminCourtGeneralInfoControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtGeneralInfoControllerTest.java
@@ -26,6 +26,8 @@ public class AdminCourtGeneralInfoControllerTest {
     private static final String BASE_PATH = "/admin/courts/";
     private static final String CHILD_PATH = "/generalInfo";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final CourtGeneralInfo COURT_GENERAL_INFO = new CourtGeneralInfo(
         "Test court name",
         true,
@@ -69,7 +71,7 @@ public class AdminCourtGeneralInfoControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -93,6 +95,6 @@ public class AdminCourtGeneralInfoControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
@@ -35,7 +35,11 @@ public class AdminCourtLocalAuthoritiesControllerTest {
     private static final String TEST_LOCAL_AUTHORITIES_PATH = "local-authorities.json";
     private static final String TEST_UNKNOWN_COURT_TYPE_MESSAGE = "Court local authority not found";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
+    private static final String JSON_NOT_FOUND_TEST_AREA_OF_LAW = String.format(MESSAGE, NOT_FOUND + TEST_AREA_OF_LAW);
+    private static final String JSON_TEST_UNKNOWN_COURT_TYPE_MESSAGE = String.format(MESSAGE, TEST_UNKNOWN_COURT_TYPE_MESSAGE);
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -62,7 +66,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + SLASH + TEST_AREA_OF_LAW + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -71,7 +75,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + SLASH + TEST_AREA_OF_LAW + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_AREA_OF_LAW + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_AREA_OF_LAW));
     }
 
     @Test
@@ -101,7 +105,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -116,7 +120,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_AREA_OF_LAW + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_AREA_OF_LAW));
     }
 
     @Test
@@ -131,6 +135,6 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + TEST_UNKNOWN_COURT_TYPE_MESSAGE + "\"}"));
+            .andExpect(content().json(JSON_TEST_UNKNOWN_COURT_TYPE_MESSAGE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
@@ -35,6 +35,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
     private static final String TEST_LOCAL_AUTHORITIES_PATH = "local-authorities.json";
     private static final String TEST_UNKNOWN_COURT_TYPE_MESSAGE = "Court local authority not found";
     private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -61,7 +62,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + SLASH + TEST_AREA_OF_LAW + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -70,7 +71,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + SLASH + TEST_AREA_OF_LAW + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND + TEST_AREA_OF_LAW));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_AREA_OF_LAW+"\"}"));
     }
 
     @Test
@@ -100,7 +101,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -115,7 +116,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND + TEST_AREA_OF_LAW));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_AREA_OF_LAW+"\"}"));
     }
 
     @Test
@@ -130,6 +131,6 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().string(TEST_UNKNOWN_COURT_TYPE_MESSAGE));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+TEST_UNKNOWN_COURT_TYPE_MESSAGE+"\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtLocalAuthoritiesControllerTest.java
@@ -62,7 +62,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + SLASH + TEST_AREA_OF_LAW + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + SLASH + TEST_AREA_OF_LAW + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_AREA_OF_LAW+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_AREA_OF_LAW + "\"}"));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -116,7 +116,7 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_AREA_OF_LAW+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_AREA_OF_LAW + "\"}"));
     }
 
     @Test
@@ -131,6 +131,6 @@ public class AdminCourtLocalAuthoritiesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+TEST_UNKNOWN_COURT_TYPE_MESSAGE+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + TEST_UNKNOWN_COURT_TYPE_MESSAGE + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimeControllerTest.java
@@ -57,7 +57,7 @@ public class AdminCourtOpeningTimeControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + OPENING_TIMES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class AdminCourtOpeningTimeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimeControllerTest.java
@@ -28,6 +28,8 @@ public class AdminCourtOpeningTimeControllerTest {
     private static final String BASE_PATH = "/admin/courts/";
     private static final String OPENING_TIMES_PATH = "/" + "openingTimes";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_OPENING_TIMES_FILE = "opening-times.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -55,7 +57,7 @@ public class AdminCourtOpeningTimeControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + OPENING_TIMES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -85,7 +87,7 @@ public class AdminCourtOpeningTimeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtOpeningTimeControllerTest.java
@@ -29,7 +29,8 @@ public class AdminCourtOpeningTimeControllerTest {
     private static final String OPENING_TIMES_PATH = "/" + "openingTimes";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final String TEST_OPENING_TIMES_FILE = "opening-times.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -57,7 +58,7 @@ public class AdminCourtOpeningTimeControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + OPENING_TIMES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class AdminCourtOpeningTimeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtPostcodeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtPostcodeControllerTest.java
@@ -35,7 +35,8 @@ public class AdminCourtPostcodeControllerTest {
     private static final String TEST_SLUG = "test-slug";
     private static final String SOURCE_SLUG = "source-slug";
     private static final String DESTINATION_SLUG = "destination-slug";
-    private static final String NOT_FOUND_PREFIX = "Not found: ";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_POSTCODE1 = "M11AA";
     private static final String TEST_POSTCODE2 = "M11BB";
     private static final String TEST_POSTCODE3 = "M11CC";
@@ -82,7 +83,7 @@ public class AdminCourtPostcodeControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + POSTCODE_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND_PREFIX + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -108,7 +109,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND_PREFIX + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
 
         verify(adminService, never()).addCourtPostcodes(any(), any());
     }
@@ -122,7 +123,7 @@ public class AdminCourtPostcodeControllerTest {
                            .contentType(MediaType.APPLICATION_JSON)
                            .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json(expectedInvalidPostcodesJson));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+INVALID_POSTCODE+"\"}"));
 
         verify(adminService, never()).addCourtPostcodes(any(), any());
     }
@@ -164,7 +165,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND_PREFIX + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
 
         verify(adminService, never()).deleteCourtPostcodes(any(), any());
     }
@@ -178,7 +179,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json(expectedInvalidPostcodesJson));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+INVALID_POSTCODE+"\"}"));
 
         verify(adminService, never()).deleteCourtPostcodes(any(), any());
     }
@@ -221,7 +222,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND_PREFIX + SOURCE_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SOURCE_SLUG+"\"}"));
     }
 
     @Test
@@ -234,7 +235,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string(NOT_FOUND_PREFIX + DESTINATION_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+DESTINATION_SLUG+"\"}"));
     }
 
     @Test
@@ -246,7 +247,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json(expectedInvalidPostcodesJson));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+INVALID_POSTCODE+"\"}"));
 
         verify(adminService, never()).moveCourtPostcodes(SOURCE_SLUG, DESTINATION_SLUG, TEST_POSTCODES);
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtPostcodeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtPostcodeControllerTest.java
@@ -83,7 +83,7 @@ public class AdminCourtPostcodeControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + POSTCODE_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
 
         verify(adminService, never()).addCourtPostcodes(any(), any());
     }
@@ -123,7 +123,7 @@ public class AdminCourtPostcodeControllerTest {
                            .contentType(MediaType.APPLICATION_JSON)
                            .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+INVALID_POSTCODE+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + INVALID_POSTCODE + "\"}"));
 
         verify(adminService, never()).addCourtPostcodes(any(), any());
     }
@@ -165,7 +165,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
 
         verify(adminService, never()).deleteCourtPostcodes(any(), any());
     }
@@ -179,7 +179,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+INVALID_POSTCODE+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + INVALID_POSTCODE + "\"}"));
 
         verify(adminService, never()).deleteCourtPostcodes(any(), any());
     }
@@ -222,7 +222,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SOURCE_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SOURCE_SLUG + "\"}"));
     }
 
     @Test
@@ -235,7 +235,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+DESTINATION_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + DESTINATION_SLUG + "\"}"));
     }
 
     @Test
@@ -247,7 +247,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+INVALID_POSTCODE+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + INVALID_POSTCODE + "\"}"));
 
         verify(adminService, never()).moveCourtPostcodes(SOURCE_SLUG, DESTINATION_SLUG, TEST_POSTCODES);
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtPostcodeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtPostcodeControllerTest.java
@@ -36,7 +36,7 @@ public class AdminCourtPostcodeControllerTest {
     private static final String SOURCE_SLUG = "source-slug";
     private static final String DESTINATION_SLUG = "destination-slug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
     private static final String TEST_POSTCODE1 = "M11AA";
     private static final String TEST_POSTCODE2 = "M11BB";
     private static final String TEST_POSTCODE3 = "M11CC";
@@ -44,6 +44,10 @@ public class AdminCourtPostcodeControllerTest {
     private static final List<String> INVALID_POSTCODE = singletonList(TEST_POSTCODE3);
     private static final List<String> EXISTED_POSTCODE = singletonList(TEST_POSTCODE2);
     private static final List<String> NOT_FOUND_POSTCODE = singletonList(TEST_POSTCODE1);
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
+    private static final String JSON_NOT_FOUND_SOURCE_SLUG = String.format(MESSAGE, NOT_FOUND + SOURCE_SLUG);
+    private static final String JSON_NOT_FOUND_DESTINATION_SLUG = String.format(MESSAGE, NOT_FOUND + DESTINATION_SLUG);
+    private static final String JSON_INVALID_POSTCODE = String.format(MESSAGE, INVALID_POSTCODE);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -56,14 +60,12 @@ public class AdminCourtPostcodeControllerTest {
     private ValidationService validationService;
 
     private static String expectedPostcodeJson;
-    private static String expectedInvalidPostcodesJson;
     private static String expectedExistedPostcodesJson;
     private static String expectedNotFoundPostcodesJson;
 
     @BeforeAll
     static void setUp() throws JsonProcessingException {
         expectedPostcodeJson = OBJECT_MAPPER.writeValueAsString(TEST_POSTCODES);
-        expectedInvalidPostcodesJson = OBJECT_MAPPER.writeValueAsString(INVALID_POSTCODE);
         expectedExistedPostcodesJson = OBJECT_MAPPER.writeValueAsString(EXISTED_POSTCODE);
         expectedNotFoundPostcodesJson = OBJECT_MAPPER.writeValueAsString(NOT_FOUND_POSTCODE);
     }
@@ -83,7 +85,7 @@ public class AdminCourtPostcodeControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + POSTCODE_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -109,7 +111,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
 
         verify(adminService, never()).addCourtPostcodes(any(), any());
     }
@@ -123,7 +125,7 @@ public class AdminCourtPostcodeControllerTest {
                            .contentType(MediaType.APPLICATION_JSON)
                            .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + INVALID_POSTCODE + "\"}"));
+            .andExpect(content().json(JSON_INVALID_POSTCODE));
 
         verify(adminService, never()).addCourtPostcodes(any(), any());
     }
@@ -165,7 +167,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
 
         verify(adminService, never()).deleteCourtPostcodes(any(), any());
     }
@@ -179,7 +181,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + INVALID_POSTCODE + "\"}"));
+            .andExpect(content().json(JSON_INVALID_POSTCODE));
 
         verify(adminService, never()).deleteCourtPostcodes(any(), any());
     }
@@ -222,7 +224,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SOURCE_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_SOURCE_SLUG));
     }
 
     @Test
@@ -235,7 +237,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + DESTINATION_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_DESTINATION_SLUG));
     }
 
     @Test
@@ -247,7 +249,7 @@ public class AdminCourtPostcodeControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + INVALID_POSTCODE + "\"}"));
+            .andExpect(content().json(JSON_INVALID_POSTCODE));
 
         verify(adminService, never()).moveCourtPostcodes(SOURCE_SLUG, DESTINATION_SLUG, TEST_POSTCODES);
     }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtSpoeAreasOfLawControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtSpoeAreasOfLawControllerTest.java
@@ -29,7 +29,8 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
     private static final String CHILD_PATH = "/SpoeAreasOfLaw";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
     private static final String TEST_COURT_AREAS_OF_LAW_PATH = "court-spoe-areas-of-law.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -72,7 +73,7 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -102,6 +103,6 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtSpoeAreasOfLawControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtSpoeAreasOfLawControllerTest.java
@@ -28,6 +28,8 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
     private static final String BASE_PATH = "/admin/courts/";
     private static final String CHILD_PATH = "/SpoeAreasOfLaw";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_COURT_AREAS_OF_LAW_PATH = "court-spoe-areas-of-law.json";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -70,7 +72,7 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -100,6 +102,6 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtSpoeAreasOfLawControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtSpoeAreasOfLawControllerTest.java
@@ -72,7 +72,7 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + CHILD_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -102,6 +102,6 @@ public class AdminCourtSpoeAreasOfLawControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
@@ -39,7 +39,7 @@ public class AdminCourtTypesAndCodesControllerTest {
     private static final String TEST_UNKNOWN_COURT_TYPE_MESSAGE = "Court type not found";
     private static final String MESSAGE = "{\"message\":\"%s\"}";
     private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
-    private static final String JSON_NOT_FOUND_TEST_UNKNOWN_COURT_TYPE_MESSAGE = String.format(MESSAGE, NOT_FOUND + TEST_UNKNOWN_COURT_TYPE_MESSAGE);
+    private static final String JSON_NOT_FOUND_TEST_UNKNOWN_COURT_TYPE_MESSAGE = String.format(MESSAGE, TEST_UNKNOWN_COURT_TYPE_MESSAGE);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
@@ -33,6 +33,8 @@ public class AdminCourtTypesAndCodesControllerTest {
     private static final String COURT_TYPES_AND_CODES_PATH = "/courtTypesAndCodes";
     private static final String COURT_TYPES_PATH = "courtTypes";
     private static final String TEST_SLUG = "unknownSlug";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final String TEST_COURT_TYPES_PATH = "court-types.json";
     private static final String TEST_COURT_TYPES_AND_CODES_PATH = "court-types-and-codes.json";
     private static final String TEST_UNKNOWN_COURT_TYPE_MESSAGE = "Court type not found";
@@ -74,7 +76,7 @@ public class AdminCourtTypesAndCodesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + COURT_TYPES_AND_CODES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
 
@@ -105,7 +107,7 @@ public class AdminCourtTypesAndCodesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: " + TEST_SLUG));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
     }
 
     @Test
@@ -120,6 +122,6 @@ public class AdminCourtTypesAndCodesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().string(TEST_UNKNOWN_COURT_TYPE_MESSAGE));
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+TEST_UNKNOWN_COURT_TYPE_MESSAGE+"\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
@@ -34,10 +34,12 @@ public class AdminCourtTypesAndCodesControllerTest {
     private static final String COURT_TYPES_PATH = "courtTypes";
     private static final String TEST_SLUG = "unknownSlug";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
     private static final String TEST_COURT_TYPES_PATH = "court-types.json";
     private static final String TEST_COURT_TYPES_AND_CODES_PATH = "court-types-and-codes.json";
     private static final String TEST_UNKNOWN_COURT_TYPE_MESSAGE = "Court type not found";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_TEST_SLUG = String.format(MESSAGE, NOT_FOUND + TEST_SLUG);
+    private static final String JSON_NOT_FOUND_TEST_UNKNOWN_COURT_TYPE_MESSAGE = String.format(MESSAGE, NOT_FOUND + TEST_UNKNOWN_COURT_TYPE_MESSAGE);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -76,7 +78,7 @@ public class AdminCourtTypesAndCodesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + COURT_TYPES_AND_CODES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
 
@@ -107,7 +109,7 @@ public class AdminCourtTypesAndCodesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_SLUG));
     }
 
     @Test
@@ -122,6 +124,6 @@ public class AdminCourtTypesAndCodesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + TEST_UNKNOWN_COURT_TYPE_MESSAGE + "\"}"));
+            .andExpect(content().json(JSON_NOT_FOUND_TEST_UNKNOWN_COURT_TYPE_MESSAGE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtTypesAndCodesControllerTest.java
@@ -76,7 +76,7 @@ public class AdminCourtTypesAndCodesControllerTest {
 
         mockMvc.perform(get(BASE_PATH + TEST_SLUG + COURT_TYPES_AND_CODES_PATH))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
 
@@ -107,7 +107,7 @@ public class AdminCourtTypesAndCodesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+TEST_SLUG+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + TEST_SLUG + "\"}"));
     }
 
     @Test
@@ -122,6 +122,6 @@ public class AdminCourtTypesAndCodesControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+TEST_UNKNOWN_COURT_TYPE_MESSAGE+"\"}"));
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + TEST_UNKNOWN_COURT_TYPE_MESSAGE + "\"}"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtsControllerTest.java
@@ -46,7 +46,8 @@ class AdminCourtsControllerTest {
     private static final String TEST_SEARCH_SLUG = "some-slug";
     private static final String SEARCH_CRITERIA = "search criteria";
     private static final String NOT_FOUND = "Not found: ";
-    private static final String MESSAGE = "message";
+    private static final String MESSAGE = "{\"message\":\"%s\"}";
+    private static final String JSON_NOT_FOUND_SEARCH_CRITERIA = String.format(MESSAGE, NOT_FOUND + SEARCH_CRITERIA);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -246,11 +247,11 @@ class AdminCourtsControllerTest {
     void shouldReturnNotFoundForUnknownSlug() throws Exception {
         final String searchSlug = TEST_SEARCH_SLUG;
 
-        when(adminService.getCourtBySlug(searchSlug)).thenThrow(new NotFoundException("search criteria"));
+        when(adminService.getCourtBySlug(searchSlug)).thenThrow(new NotFoundException(SEARCH_CRITERIA));
 
         mockMvc.perform(get(String.format(TEST_URL + "/%s/general", searchSlug)))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SEARCH_CRITERIA + "\"}"))
+            .andExpect(content().json(JSON_NOT_FOUND_SEARCH_CRITERIA))
             .andReturn();
     }
 
@@ -266,10 +267,10 @@ class AdminCourtsControllerTest {
 
     @Test
     void shouldNotReturnCourtImageFileForUnknownSlug() throws Exception {
-        when(adminService.getCourtImage(TEST_SEARCH_SLUG)).thenThrow(new NotFoundException("search criteria"));
+        when(adminService.getCourtImage(TEST_SEARCH_SLUG)).thenThrow(new NotFoundException(SEARCH_CRITERIA));
         mockMvc.perform(get(String.format(TEST_URL + TEST_COURT_PHOTO_URL, TEST_SEARCH_SLUG)))
                             .andExpect(status().isNotFound())
-                            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SEARCH_CRITERIA + "\"}"))
+                            .andExpect(content().json(JSON_NOT_FOUND_SEARCH_CRITERIA))
                             .andReturn();
     }
 
@@ -300,13 +301,13 @@ class AdminCourtsControllerTest {
 
         String json = mapper.writeValueAsString(imageFile);
 
-        when(adminService.updateCourtImage(TEST_SEARCH_SLUG, imageFile.getImageName())).thenThrow(new NotFoundException("search criteria"));
+        when(adminService.updateCourtImage(TEST_SEARCH_SLUG, imageFile.getImageName())).thenThrow(new NotFoundException(SEARCH_CRITERIA));
         mockMvc.perform(put(String.format(TEST_URL + TEST_COURT_PHOTO_URL, TEST_SEARCH_SLUG))
                             .content(json)
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SEARCH_CRITERIA + "\"}"))
+            .andExpect(content().json(JSON_NOT_FOUND_SEARCH_CRITERIA))
             .andReturn();
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtsControllerTest.java
@@ -250,7 +250,7 @@ class AdminCourtsControllerTest {
 
         mockMvc.perform(get(String.format(TEST_URL + "/%s/general", searchSlug)))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SEARCH_CRITERIA+"\"}"))
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SEARCH_CRITERIA + "\"}"))
             .andReturn();
     }
 
@@ -269,7 +269,7 @@ class AdminCourtsControllerTest {
         when(adminService.getCourtImage(TEST_SEARCH_SLUG)).thenThrow(new NotFoundException("search criteria"));
         mockMvc.perform(get(String.format(TEST_URL + TEST_COURT_PHOTO_URL, TEST_SEARCH_SLUG)))
                             .andExpect(status().isNotFound())
-                            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SEARCH_CRITERIA+"\"}"))
+                            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SEARCH_CRITERIA + "\"}"))
                             .andReturn();
     }
 
@@ -306,7 +306,7 @@ class AdminCourtsControllerTest {
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNotFound())
-            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SEARCH_CRITERIA+"\"}"))
+            .andExpect(content().json("{\"" + MESSAGE + "\":\"" + NOT_FOUND + SEARCH_CRITERIA + "\"}"))
             .andReturn();
     }
 }

--- a/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/controllers/admin/AdminCourtsControllerTest.java
@@ -44,6 +44,9 @@ class AdminCourtsControllerTest {
     private static final String TEST_GENERAL_FILE = "birmingham-civil-and-family-justice-centre-general.json";
     private static final String TEST_COURT_ENTITY_FILE = "full-birmingham-civil-and-family-justice-centre-entity.json";
     private static final String TEST_SEARCH_SLUG = "some-slug";
+    private static final String SEARCH_CRITERIA = "search criteria";
+    private static final String NOT_FOUND = "Not found: ";
+    private static final String MESSAGE = "message";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Autowired
@@ -247,7 +250,7 @@ class AdminCourtsControllerTest {
 
         mockMvc.perform(get(String.format(TEST_URL + "/%s/general", searchSlug)))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: search criteria"))
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SEARCH_CRITERIA+"\"}"))
             .andReturn();
     }
 
@@ -266,7 +269,7 @@ class AdminCourtsControllerTest {
         when(adminService.getCourtImage(TEST_SEARCH_SLUG)).thenThrow(new NotFoundException("search criteria"));
         mockMvc.perform(get(String.format(TEST_URL + TEST_COURT_PHOTO_URL, TEST_SEARCH_SLUG)))
                             .andExpect(status().isNotFound())
-                            .andExpect(content().string("Not found: search criteria"))
+                            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SEARCH_CRITERIA+"\"}"))
                             .andReturn();
     }
 
@@ -303,7 +306,7 @@ class AdminCourtsControllerTest {
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                             .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNotFound())
-            .andExpect(content().string("Not found: search criteria"))
+            .andExpect(content().json("{\""+MESSAGE+"\":\""+NOT_FOUND+SEARCH_CRITERIA+"\"}"))
             .andReturn();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1178


### Change description ###
changed exceptions to return json object instead of returning a string. former error messages now return under 'message' name value pair.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
