### PR TITLE
FACT-1457 fixing key mismatch in keyvault to code

### DIFF
--- a/charts/fact-api/values.yaml
+++ b/charts/fact-api/values.yaml
@@ -16,13 +16,13 @@ java:
   keyVaults:
     fact:
       secrets:
-        - name: api-POSTGRES-HOST-FLEXIBLE
+        - name: api-POSTGRES-FLEXIBLE-HOST
           alias: POSTGRES_HOST
-        - name: api-POSTGRES-PASS-FLEXIBLE
+        - name: api-POSTGRES-FLEXIBLE-PASS
           alias: POSTGRES_PASSWORD
-        - name: api-POSTGRES-DATABASE-FLEXIBLE
+        - name: api-POSTGRES-FLEXIBLE-DATABASE
           alias: POSTGRES_DATABASE
-        - name: api-POSTGRES-USER-FLEXIBLE
+        - name: api-POSTGRES-FLEXIBLE-USER
           alias: POSTGRES_USER
         - name: AppInsightsInstrumentationKey
           alias: APPINSIGHTS_INSTRUMENTATIONKEY


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1457

### Change description ###
changed following keys to match value in fact-aat key vault

api-POSTGRES-FLEXIBLE-HOST
name: api-POSTGRES-FLEXIBLE-PASS
name: api-POSTGRES-FLEXIBLE-DATABASE
name: api-POSTGRES-FLEXIBLE-USER

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
