### PR TITLE
FACT-1784 - fixes court deletion

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
@@ -73,7 +73,7 @@ public class Court {
     )
     private List<AreaOfLaw> areasOfLaw;
 
-    @OneToMany(cascade = CascadeType.REMOVE)
+    @OneToMany
     @JoinTable(
         name = "search_courtareaoflawspoe",
         joinColumns = @JoinColumn(name = COURT_ID),
@@ -137,7 +137,7 @@ public class Court {
     )
     private List<ServiceArea> serviceAreas;
 
-    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = COURT_STRING)
+    @OneToMany(mappedBy = COURT_STRING)
     private List<ServiceAreaCourt> serviceAreaCourts;
 
     @OneToMany(mappedBy = COURT_STRING, orphanRemoval = true)

--- a/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/entity/Court.java
@@ -73,7 +73,7 @@ public class Court {
     )
     private List<AreaOfLaw> areasOfLaw;
 
-    @OneToMany
+    @OneToMany(cascade = CascadeType.REMOVE)
     @JoinTable(
         name = "search_courtareaoflawspoe",
         joinColumns = @JoinColumn(name = COURT_ID),
@@ -117,7 +117,7 @@ public class Court {
     )
     private List<Facility> facilities;
 
-    @OneToMany(mappedBy = COURT_STRING)
+    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = COURT_STRING)
     @OrderBy("sort_order")
     private List<CourtAddress> addresses;
 
@@ -137,7 +137,7 @@ public class Court {
     )
     private List<ServiceArea> serviceAreas;
 
-    @OneToMany(mappedBy = COURT_STRING)
+    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = COURT_STRING)
     private List<ServiceAreaCourt> serviceAreaCourts;
 
     @OneToMany(mappedBy = COURT_STRING, orphanRemoval = true)

--- a/src/main/java/uk/gov/hmcts/dts/fact/repositories/CourtLocalAuthorityAreaOfLawRepository.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/repositories/CourtLocalAuthorityAreaOfLawRepository.java
@@ -10,4 +10,6 @@ public interface CourtLocalAuthorityAreaOfLawRepository extends JpaRepository<Co
     List<CourtLocalAuthorityAreaOfLaw> findByCourtId(Integer courtId);
 
     List<CourtLocalAuthorityAreaOfLaw> findByAreaOfLawId(Integer areaOfLawId);
+
+    List<CourtLocalAuthorityAreaOfLaw> deleteByCourtId(Integer courtId);
 }

--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminService.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.dts.fact.model.admin.Court;
 import uk.gov.hmcts.dts.fact.model.admin.CourtInfoUpdate;
 import uk.gov.hmcts.dts.fact.repositories.AreasOfLawRepository;
 import uk.gov.hmcts.dts.fact.repositories.CourtHistoryRepository;
+import uk.gov.hmcts.dts.fact.repositories.CourtLocalAuthorityAreaOfLawRepository;
 import uk.gov.hmcts.dts.fact.repositories.CourtRepository;
 import uk.gov.hmcts.dts.fact.repositories.ServiceAreaRepository;
 import uk.gov.hmcts.dts.fact.util.AuditType;
@@ -49,6 +50,8 @@ public class AdminService {
 
     private final CourtHistoryRepository courtHistoryRepository;
 
+    private final CourtLocalAuthorityAreaOfLawRepository courtLocalAuthorityAreaOfLawRepository;
+
     private static final String INTRO_PARAGRAPH = "This location services all of England and Wales for {serviceArea}. We do not provide an in-person service.";
     private static final String INTRO_PARAGRAPH_CY = "Mae’r lleoliad hwn yn gwasanaethu Cymru a Lloegr i gyd ar gyfer {serviceArea}. Nid ydym yn darparu gwasanaeth wyneb yn wyneb.";
 
@@ -66,13 +69,15 @@ public class AdminService {
                         final AdminAuditService adminAuditService,
                         final ServiceAreaRepository serviceAreaRepository,
                         final AreasOfLawRepository areasOfLawRepository,
-                        CourtHistoryRepository courtHistoryRepository) {
+                        CourtHistoryRepository courtHistoryRepository,
+                        CourtLocalAuthorityAreaOfLawRepository courtLocalAuthorityAreaOfLawRepository) {
         this.courtRepository = courtRepository;
         this.rolesProvider = rolesProvider;
         this.adminAuditService = adminAuditService;
         this.serviceAreaRepository = serviceAreaRepository;
         this.areasOfLawRepository = areasOfLawRepository;
         this.courtHistoryRepository = courtHistoryRepository;
+        this.courtLocalAuthorityAreaOfLawRepository = courtLocalAuthorityAreaOfLawRepository;
     }
 
     /**
@@ -310,6 +315,7 @@ public class AdminService {
         adminAuditService.saveAudit(AuditType.findByName("Delete existing court"), new Court(court),
                                     null, courtSlug);
         courtHistoryRepository.deleteCourtHistoriesBySearchCourtId(court.getId());
+        courtLocalAuthorityAreaOfLawRepository.deleteByCourtId(court.getId());
         courtRepository.deleteById(court.getId());
     }
 

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.dts.fact.model.CourtReference;
 import uk.gov.hmcts.dts.fact.model.admin.CourtInfoUpdate;
 import uk.gov.hmcts.dts.fact.repositories.AreasOfLawRepository;
 import uk.gov.hmcts.dts.fact.repositories.CourtHistoryRepository;
+import uk.gov.hmcts.dts.fact.repositories.CourtLocalAuthorityAreaOfLawRepository;
 import uk.gov.hmcts.dts.fact.repositories.CourtRepository;
 import uk.gov.hmcts.dts.fact.repositories.ServiceAreaRepository;
 
@@ -82,6 +83,9 @@ class AdminServiceTest {
 
     @MockBean
     private AdminAuditService adminAuditService;
+
+    @MockBean
+    private CourtLocalAuthorityAreaOfLawRepository courtLocalAuthorityAreaOfLawRepository;
 
     @BeforeEach
     void setUp() {
@@ -318,6 +322,7 @@ class AdminServiceTest {
                                             any(), anyString()
         );
         verify(courtHistoryRepository).deleteCourtHistoriesBySearchCourtId(courtEntity.getId());
+        verify(courtLocalAuthorityAreaOfLawRepository).deleteByCourtId(courtEntity.getId());
     }
 
     @Test
@@ -328,6 +333,7 @@ class AdminServiceTest {
             .isInstanceOf(NotFoundException.class)
             .hasMessage(NOT_FOUND + notFoundSlugError);
         verify(courtHistoryRepository, never()).deleteCourtHistoriesBySearchCourtId(any());
+        verify(courtLocalAuthorityAreaOfLawRepository, never()).deleteByCourtId(any());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1784

### Change description ###

- Adds the cascading removal of the address of court so court can be deleted
- Adds deleting the local authority area of law of court before the court is deleted
- Updates unit tests for court deletion method

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
