### PR TITLE
FACT-2000 altered audit page to show in gmt/bst on creationdate

### DIFF
--- a/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminAuditService.java
+++ b/src/main/java/uk/gov/hmcts/dts/fact/services/admin/AdminAuditService.java
@@ -66,12 +66,12 @@ public class AdminAuditService {
             .stream()
             .map(audit -> {
                 // Convert UTC LocalDateTime to ZonedDateTime for Europe/London
-                ZonedDateTime creationTimeInUK = audit.getCreationTime()
+                ZonedDateTime creationTimeInUk = audit.getCreationTime()
                     .atZone(ZoneId.of("UTC"))
                     .withZoneSameInstant(ZoneId.of("Europe/London")); // show as GMT/BST
                 // Map to the DTO, adjusting the creation time
                 uk.gov.hmcts.dts.fact.model.admin.Audit dto = new uk.gov.hmcts.dts.fact.model.admin.Audit(audit);
-                dto.setCreationTime(creationTimeInUK.toLocalDateTime()); // Update creation time
+                dto.setCreationTime(creationTimeInUk.toLocalDateTime()); // Update creation time
                 return dto;
             })
             .collect(Collectors.toList());

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminAuditServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminAuditServiceTest.java
@@ -114,9 +114,6 @@ class AdminAuditServiceTest {
         ZoneId londonZone = ZoneId.of("Europe/London");
         ZonedDateTime bstZonedDateTime = ZonedDateTime.of(2024, 6, 21, 14, 30, 10, 0, londonZone);
 
-        // See if we're currently in BST
-        boolean currentlyInBST = londonZone.getRules().isDaylightSavings(bstZonedDateTime.toInstant());
-
         Audit bstAudit = new Audit("BST Test", new AuditType(2, "BST"),
                                    "before BST", "after BST",
                                    "some court", bstZonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime());
@@ -130,8 +127,10 @@ class AdminAuditServiceTest {
         verify(auditRepository, atLeastOnce()).findAllByLocationContainingAndUserEmailContainingOrderByCreationTimeDesc(
             TEST_LOCATION, TEST_EMAIL, PageRequest.of(0, 10));
 
+        // See if we're currently in BST
+        boolean currentlyInBst = londonZone.getRules().isDaylightSavings(bstZonedDateTime.toInstant());
         // Perform the assertion dynamically based on BST or UTC because BST tests won't work unless we're in BST
-        if (currentlyInBST) {
+        if (currentlyInBst) {
             assertThat(results.get(0).getCreationTime())
                 .isEqualTo(bstZonedDateTime.toLocalDateTime());
         } else {

--- a/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminAuditServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/dts/fact/services/admin/AdminAuditServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.dts.fact.repositories.AuditRepository;
 import uk.gov.hmcts.dts.fact.repositories.AuditTypeRepository;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -51,12 +52,20 @@ class AdminAuditServiceTest {
 
     @BeforeAll
     static void beforeAll() {
+        ZoneId utcZone = ZoneId.of("Europe/London");
+
         AUDIT_DATA.add(new Audit("Test String", new AuditType(1, "test"),
-                               "data before", "data after",
-                               "some court", LocalDateTime.of(1000, 10, 10, 10, 10)));
+                                 "data before", "data after",
+                                 "some court", LocalDateTime.of(2024, 11, 10, 10, 10, 10)
+                                     .atZone(utcZone)
+                                     .toLocalDateTime()));
+
         AUDIT_DATA.add(new Audit("Test String 2", new AuditType(1, "test 2"),
-                               "data before 2", "data after 2",
-                               "some court", LocalDateTime.of(1000, 10, 10, 10, 10)));
+                                 "data before 2", "data after 2",
+                                 "some court", LocalDateTime.of(2024, 11, 10, 10, 10, 10)
+                                     .atZone(utcZone)
+                                     .toLocalDateTime()));
+
         AUDIT_DATA.get(0).setId(0);
         AUDIT_DATA.get(1).setId(1);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-2000


### Change description ###
changed audit page to show date in the timestamp as gmt/bst


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
