### PR TITLE
FACT-2524 datafix for wrong court returning for money-claims

### DIFF
--- a/src/main/resources/db/migration/V212__remove_tec_court_for_money_claims.sql
+++ b/src/main/resources/db/migration/V212__remove_tec_court_for_money_claims.sql
@@ -2,9 +2,14 @@
 --Remove the entry in search_serviceareacourt that points to traffic enforcement centre tec for money claims
 --CNBC will remain and system will point there instead
 
-WITH tec_id AS (
-  SELECT id FROM search_court WHERE slug IN ('traffic-enforcement-centre-tec') LIMIT 1
+WITH
+tec_id AS (
+  SELECT id FROM search_court WHERE slug = 'traffic-enforcement-centre-tec' LIMIT 1
+),
+sa_id AS (
+SELECT id FROM search_servicearea WHERE name = 'Money claims' LIMIT 1
 )
 DELETE FROM search_serviceareacourt ssac
-WHERE ssac.court_id = (SELECT id FROM tec_id)
-AND ssac.catchment_type = 'national';
+WHERE ssac.court_id = (SELECT id FROM tec_id) AND
+  ssac.servicearea_id = (SELECT id FROM sa_id) AND
+  ssac.catchment_type = 'national';


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-2524


### Change description ###
locally theres one money claims national court in search_serviceareacourt. in prod theres two. one for the right court CNBC and the other is TEC. Locally i added the TEC and it went to the wrong court like in prod. removing again locally fixed the issue. removing from prod should allow the system to point back to CNBC


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
