### PR TITLE
FACT-2712 

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/dts/fact/CourtsEndpointTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/dts/fact/CourtsEndpointTest.java
@@ -154,23 +154,33 @@ class CourtsEndpointTest extends AdminFunctionalTestBase {
     }
 
     @Test
-    void shouldRetrieveCourtsByPrefixWhereDisplayedFalseAndCaseLower() {
-        final var response = doGetRequest(COURT_SEARCH_BY_PREFIX_AND_ACTIVE_ENDPOINT + "?prefix=a&active=false");
+    void shouldRetrieveDisplayedCourtsByLowerCasePrefix() {
+        final var response = doGetRequest(COURT_SEARCH_BY_PREFIX_AND_ACTIVE_ENDPOINT + "?prefix=a");
         assertThat(response.statusCode()).isEqualTo(OK.value());
 
         final List<CourtReference> courtReferences = response.body().jsonPath().getList(".", CourtReference.class);
-        assertTrue(courtReferences.stream().allMatch(c -> c.getName().charAt(0) == 'A'));
-        assertTrue(courtReferences.stream().allMatch(c -> c.getSlug().charAt(0) == 'a'));
+        assertThat(courtReferences)
+            .isNotEmpty()
+            .allSatisfy(court -> {
+                assertThat(court.getName()).startsWithIgnoringCase("a");
+                assertThat(court.getSlug()).startsWith("a");
+                assertThat(court.isDisplayed()).isTrue();
+            });
     }
 
     @Test
-    void shouldRetrieveCourtsByPrefixWhereDispayedTrueAndCaseUpper() {
-        final var response = doGetRequest(COURT_SEARCH_BY_PREFIX_AND_ACTIVE_ENDPOINT + "?prefix=B&active=true");
+    void shouldRetrieveDisplayedCourtsByUpperCasePrefix() {
+        final var response = doGetRequest(COURT_SEARCH_BY_PREFIX_AND_ACTIVE_ENDPOINT + "?prefix=B");
         assertThat(response.statusCode()).isEqualTo(OK.value());
 
         final List<CourtReference> courtReferences = response.body().jsonPath().getList(".", CourtReference.class);
-        assertTrue(courtReferences.stream().allMatch(c -> c.getName().charAt(0) == 'B'));
-        assertTrue(courtReferences.stream().allMatch(c -> c.getSlug().charAt(0) == 'b'));
+        assertThat(courtReferences)
+            .isNotEmpty()
+            .allSatisfy(court -> {
+                assertThat(court.getName()).startsWithIgnoringCase("b");
+                assertThat(court.getSlug()).startsWith("b");
+                assertThat(court.isDisplayed()).isTrue();
+            });
     }
 
     @Test

--- a/src/main/resources/db/migration/V218__correct_missing_court_regions.sql
+++ b/src/main/resources/db/migration/V218__correct_missing_court_regions.sql
@@ -1,0 +1,31 @@
+WITH court_region_map (court_slug, region_id, region_name, country) AS (
+  VALUES
+    ('ayr-social-security-and-child-support-tribunal', 15, 'Scotland', 'Scotland'),
+    ('crime-service-centre', 7, 'London', 'England'),
+    ('bury-st-edmunds-regional-divorce-centre', 7, 'London', 'England'),
+    ('london-regional-confiscation-unit', 7, 'London', 'England'),
+    ('social-security-and-child-support-appeals-service-centre', 7, 'London', 'England'),
+    ('maintenance-enforcement-business-centre', 7, 'London', 'England'),
+    ('small-claims-mediation-service-scms', 7, 'London', 'England'),
+    ('immigration-and-asylum-appeals-service-centre', 7, 'London', 'England'),
+    ('humberside-enforcement-unit', 9, 'Yorkshire and the Humber', 'England'),
+    ('divorce-service-centre', 7, 'London', 'England'),
+    ('south-yorkshire-enforcement-unit', 9, 'Yorkshire and the Humber', 'England'),
+    ('single-justice-procedures-service-centre', 7, 'London', 'England'),
+    ('north-east-regional-confiscation-unit', 3, 'North East', 'England'),
+    ('south-east-regional-confiscation-unit', 4, 'South East', 'England'),
+    ('midlands-regional-confiscation-unit', 8, 'West Midlands', 'England'),
+    ('online-civil-money-claims-service-centre', 7, 'London', 'England'),
+    ('wales-and-south-west-confiscation-unit', 10, 'South Wales West', 'Wales'),
+    ('probate-service-centre', 7, 'London', 'England'),
+    ('north-west-regional-confiscation-unit', 2, 'North West', 'England')
+)
+UPDATE public.search_court court
+SET region_id = mapping.region_id
+FROM court_region_map mapping
+JOIN public.search_region region
+  ON region.id = mapping.region_id
+  AND region.name = mapping.region_name
+  AND region.country = mapping.country
+WHERE court.slug = mapping.court_slug
+  AND court.region_id IS NULL;


### PR DESCRIPTION
Adds a Flyway migration to assign reviewed regions to the courts with null regions, ensuring Ayr is included in the FaCT migration. Also updates brittle prefix-search functional tests to handle lowercase court names correctly.